### PR TITLE
Instance field assignment in the constructor of the ApplicationContext

### DIFF
--- a/Allure.Commons/AllureLifecycle.cs
+++ b/Allure.Commons/AllureLifecycle.cs
@@ -25,6 +25,10 @@ namespace Allure.Commons
             AllureConfiguration = AllureConfiguration.ReadFromJson(JsonConfiguration);
             writer = new FileSystemResultsWriter(AllureConfiguration);
             storage = new AllureStorage();
+            lock (lockobj)
+            {
+                instance = this;
+            }
         }
 
         public string JsonConfiguration { get; } = string.Empty;
@@ -39,7 +43,8 @@ namespace Allure.Commons
                 if (instance == null)
                     lock (lockobj)
                     {
-                        instance = instance ?? new AllureLifecycle();
+                        if (instance == null)                        
+                            new AllureLifecycle();
                     }
 
                 return instance;


### PR DESCRIPTION
There is an issue by which when we initialize ApplicationContext with the constructor and with json config parameter it doesn’t assign the Instance field, which is used by others libraries which can directly referenced to Instance property. When this property not initialized, it calls this constructor without argument and then execution of this class is incorrect.