### PR TITLE
Add ability to use custom labels in SpecFlow plugin

### DIFF
--- a/Allure.Features/TestData/Labels.feature
+++ b/Allure.Features/TestData/Labels.feature
@@ -18,3 +18,6 @@ Feature: Labels
 
   @passed @epic:v.2.0 @story:security @package:com.company.security @class:main @method:getACL
   Scenario: [v1.2 / v.2.0 security] [core.update] [com.company.security.main.getACL] Get ACL test
+      
+  @passed @layer(e2e) @as_id(9869)
+  Scenario: Custom label

--- a/Allure.Features/TestData/Labels.feature
+++ b/Allure.Features/TestData/Labels.feature
@@ -19,5 +19,5 @@ Feature: Labels
   @passed @epic:v.2.0 @story:security @package:com.company.security @class:main @method:getACL
   Scenario: [v1.2 / v.2.0 security] [core.update] [com.company.security.main.getACL] Get ACL test
       
-  @passed @layer(e2e) @as_id(9894) @custom_label(pepa)
+  @passed @label:layer:e2e @label:as_id:9894 @label:custom_label:pepa
   Scenario: Layer e2e (label)

--- a/Allure.Features/TestData/Labels.feature
+++ b/Allure.Features/TestData/Labels.feature
@@ -19,5 +19,5 @@ Feature: Labels
   @passed @epic:v.2.0 @story:security @package:com.company.security @class:main @method:getACL
   Scenario: [v1.2 / v.2.0 security] [core.update] [com.company.security.main.getACL] Get ACL test
       
-  @passed @layer(e2e) @as_id(9869)
-  Scenario: Custom label
+  @passed @layer(e2e) @as_id(9894) @custom_label(pepa)
+  Scenario: Layer e2e (label)

--- a/Allure.Features/allureConfig.json
+++ b/Allure.Features/allureConfig.json
@@ -31,7 +31,8 @@
     },
     "labels": {
       "owner": "^owner:?(.+)",
-      "severity": "^(normal|blocker|critical|minor|trivial)"
+      "severity": "^(normal|blocker|critical|minor|trivial)",
+      "label": "(.+)\\((.+)\\)"
     },
     "links": {
       "link": "^link:(.+)",

--- a/Allure.Features/allureConfig.json
+++ b/Allure.Features/allureConfig.json
@@ -32,7 +32,7 @@
     "labels": {
       "owner": "^owner:?(.+)",
       "severity": "^(normal|blocker|critical|minor|trivial)",
-      "label": "(.+)\\((.+)\\)"
+      "label": "^label:([\\w]+):(.+)"
     },
     "links": {
       "link": "^link:(.+)",

--- a/Allure.Net.Commons/Model/allure2.Extensions.cs
+++ b/Allure.Net.Commons/Model/allure2.Extensions.cs
@@ -129,6 +129,15 @@ namespace Allure.Net.Commons
                 value = value
             };
         }
+        
+        public static Label CustomLabel(string key, string value)
+        {
+            return new Label
+            {
+                name = key,
+                value = value
+            };
+        }
     }
 
     public partial class Link

--- a/Allure.Net.Commons/Model/allure2.Extensions.cs
+++ b/Allure.Net.Commons/Model/allure2.Extensions.cs
@@ -129,15 +129,6 @@ namespace Allure.Net.Commons
                 value = value
             };
         }
-        
-        public static Label CustomLabel(string key, string value)
-        {
-            return new Label
-            {
-                name = key,
-                value = value
-            };
-        }
     }
 
     public partial class Link

--- a/Allure.SpecFlowPlugin.Tests/IntegrationTests.cs
+++ b/Allure.SpecFlowPlugin.Tests/IntegrationTests.cs
@@ -170,6 +170,18 @@ namespace Allure.SpecFlowPlugin.Tests
     }
 
     [Test]
+    public void ShouldParseCustomLabel()
+    {
+      var scenarios = allureTestResults
+        .Where(x => x.labels.Any(l => l.value == "labels"));
+
+      var labels = scenarios.SelectMany(x => x.labels);
+
+      Assert.That(labels.Where(x => x.value == "pepa").Select(l => l.name),
+        Has.Exactly(1).Items.And.All.EqualTo("custom_label"));
+    }
+
+    [Test]
     public void ShouldAddParametersForScenarioExamples()
     {
       var parameters = allureTestResults.Where(x => x.name == "Scenario with examples").SelectMany(x => x.parameters).ToArray();

--- a/Allure.SpecFlowPlugin/PluginConfiguration.cs
+++ b/Allure.SpecFlowPlugin/PluginConfiguration.cs
@@ -46,6 +46,7 @@
     {
         public string owner { get; set; }
         public string severity { get; set; }
+        public string label { get; set; }
     }
 
     public class Links

--- a/Allure.SpecFlowPlugin/PluginHelper.cs
+++ b/Allure.SpecFlowPlugin/PluginHelper.cs
@@ -239,7 +239,7 @@ namespace Allure.SpecFlowPlugin
         // label
         if (GetLabelProps(PluginConfiguration.labels.label, tagValue, out var props))
         {
-          result.Item1.Add(Label.CustomLabel(props.Key, props.Value));
+          result.Item1.Add(new Label { name = props.Key, value = props.Value});
           continue;
         }
         

--- a/Allure.SpecFlowPlugin/PluginHelper.cs
+++ b/Allure.SpecFlowPlugin/PluginHelper.cs
@@ -236,6 +236,13 @@ namespace Allure.SpecFlowPlugin
           continue;
         }
 
+        // label
+        if (GetLabelProps(PluginConfiguration.labels.label, tagValue, out var props))
+        {
+          result.Item1.Add(Label.CustomLabel(props.Key, props.Value));
+          continue;
+        }
+        
         // tag
         result.Item1.Add(Label.Tag(tagValue));
       }
@@ -261,37 +268,66 @@ namespace Allure.SpecFlowPlugin
 
     private static bool TryUpdateValueByMatch(string expression, ref string value)
     {
-      if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(expression))
+      var matchedGroups = GetMatchedGroups(expression, value);
+
+      if (!matchedGroups.Any()) return false;
+      
+      if (matchedGroups.Count == 1)
+        value = matchedGroups[0];
+      else
+        value = matchedGroups[1];
+      return true;
+    }
+
+    private static bool GetLabelProps(string expression, string value, out KeyValuePair<string, string> props)
+    {
+      props = default;
+       
+      var matchedGroups = GetMatchedGroups(expression, value);
+
+      if (matchedGroups.Count != 3)
         return false;
+      
+      props = new KeyValuePair<string, string>(matchedGroups[1], matchedGroups[2]);
+      return true;
+
+    }
+    
+    private static List<string> GetMatchedGroups(string expression, string value)
+    {
+      var matchedGroups = new List<string>();
+      if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(expression))
+        return matchedGroups;
 
       Regex regex = null;
       try
       {
         regex = new Regex(expression,
-            RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
+          RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase);
       }
       catch (Exception)
       {
-        return false;
+        return matchedGroups;
       }
 
       if (regex == null)
-        return false;
+        return matchedGroups;
 
       if (regex.IsMatch(value))
       {
         var groups = regex.Match(value).Groups;
-        if (groups?.Count == 1)
-          value = groups[0].Value;
-        else
-          value = groups[1].Value;
 
-        return true;
+        for (var i = 0; i < groups.Count; i++)
+        {
+          matchedGroups.Add(groups[i].Value);
+        }
+
+        return matchedGroups;
       }
 
-      return false;
+      return matchedGroups;
     }
-
+    
     private static int GetDeterministicHashCode(this string str)
     {
       unchecked

--- a/Allure.SpecFlowPlugin/README.md
+++ b/Allure.SpecFlowPlugin/README.md
@@ -111,6 +111,20 @@ Scenario: ....
 ```
 will set current scenario severity in Allure report as Blocker
 
+#### Label
+You can add Label for your scenarios using tags. It can be configured in `allureConfig.json`
+``` json
+ "labels": {
+      "label": "(.+)\\((.+)\\)"
+    },
+```
+The following scenario
+``` cucumber
+@layer(e2e) @as_id(123)
+Scenario: ....
+```
+will set current scenario Layer as Blocker and Id as 123 in Allure report
+
 #### Tables conversion
 Table arguments in SpecFlow steps can be converted either to step csv-attacments or step parameters in the Allure report. The conversion is configurable in `specflow:stepArguments` config section.
 With `specflow:stepArguments:convertToParameters` set to `true` the following table arguments will be represented as parameters:

--- a/Allure.SpecFlowPlugin/README.md
+++ b/Allure.SpecFlowPlugin/README.md
@@ -115,15 +115,15 @@ will set current scenario severity in Allure report as Blocker
 You can add Label for your scenarios using tags. It can be configured in `allureConfig.json`
 ``` json
  "labels": {
-      "label": "(.+)\\((.+)\\)"
+      "label": "^label:([\\w]+):(.+)"
     },
 ```
 The following scenario
 ``` cucumber
-@layer(e2e) @as_id(123)
+@label:layer:e2e: @label:as_id:123
 Scenario: ....
 ```
-will set current scenario Layer as Blocker and Id as 123 in Allure report
+will set current scenario Layer as e2e and Id as 123 in Allure report
 
 #### Tables conversion
 Table arguments in SpecFlow steps can be converted either to step csv-attacments or step parameters in the Allure report. The conversion is configurable in `specflow:stepArguments` config section.


### PR DESCRIPTION
### Context
Can't use Layer, AllureId fields with SpecFlow Plugin

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
