### PR TITLE
Add AllureId attribute

### DIFF
--- a/Allure.NUnit.Examples/AllureIdTest.cs
+++ b/Allure.NUnit.Examples/AllureIdTest.cs
@@ -1,0 +1,15 @@
+using NUnit.Allure.Attributes;
+using NUnit.Framework;
+
+namespace Allure.NUnit.Examples
+{
+    [AllureSuite("Tests - Id")]
+    public class AllureIdTest : BaseTest
+    {
+        [Test]
+        [AllureId(345)]
+        public void StaticIdTest()
+        {
+        }
+    }
+}

--- a/Allure.NUnit/Attributes/AllureIdAttribute.cs
+++ b/Allure.NUnit/Attributes/AllureIdAttribute.cs
@@ -15,7 +15,7 @@ namespace NUnit.Allure.Attributes
 
         public override void UpdateTestResult(TestResult testResult)
         {
-            testResult.labels.Add(new Label {name = "AS_ID", value = Id.ToString()});
+            testResult.labels.Add(new Label {name = "ALLURE_ID", value = Id.ToString()});
         }
     }
 }

--- a/Allure.NUnit/Attributes/AllureIdAttribute.cs
+++ b/Allure.NUnit/Attributes/AllureIdAttribute.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Allure.Net.Commons;
+
+namespace NUnit.Allure.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class AllureIdAttribute : AllureTestCaseAttribute
+    {
+        public AllureIdAttribute(int id)
+        {
+            Id = id;
+        }
+
+        private int Id { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            testResult.labels.Add(new Label {name = "AS_ID", value = Id.ToString()});
+        }
+    }
+}

--- a/Allure.NUnit/README.md
+++ b/Allure.NUnit/README.md
@@ -37,6 +37,7 @@ public class Tests
     [AllureIssue("GitHub#1", "https://github.com/unickq/allure-nunit")]
     [AllureSeverity(SeverityLevel.critical)]
     [AllureFeature("Core")]
+    [AllureId(123)]
     public void EvenTest([Range(0, 5)] int value)
     {
         SayHello();


### PR DESCRIPTION
### Context
Added new Allure NUnit attribute because it's very inconvenient to write `[AllureLabel("AS_ID", "123")]` for every test.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
