### PR TITLE
Fixed NullPointerException if StepLogger was null

### DIFF
--- a/Allure.NUnit/Core/StepsHelper.cs
+++ b/Allure.NUnit/Core/StepsHelper.cs
@@ -43,7 +43,7 @@ namespace NUnit.Allure.Core
             };
 
             AllureLifecycle.Instance.StartAfterFixture(TestResultAccessor.TestResultContainer.uuid, fixtureResult, out var uuid);
-            StepLogger.AfterStarted?.Log(name);
+            StepLogger?.AfterStarted?.Log(name);
             return uuid;
         }
 


### PR DESCRIPTION
An exception was thrown if StepLogger was null.