### PR TITLE
[NUnit] Add support for "{paramName}" and "{paramName.fieldOrProperty}" placeholders in [AllureStep] step name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,5 @@ __pycache__/
 .DS_Store
 *mono_crash*
 /.vscode
+
+.editorconfig

--- a/Allure.NUnit.Examples/AllureStepNameInternalsTest.cs
+++ b/Allure.NUnit.Examples/AllureStepNameInternalsTest.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Allure.Attributes;
+using NUnit.Allure.Core.Steps;
+using NUnit.Framework;
+
+namespace Allure.NUnit.Examples
+{
+    [AllureSuite("Tests - Step Names")]
+    public class AllureStepNameInternalsTest : BaseTest
+    {
+        internal class LocalTestClass
+        {
+            public string TestField;
+            public string TestProp { get; set; }
+
+            public void TestMethod(string name, LocalTestClass request, int id)
+            {
+                Console.WriteLine($"{id} - {name} ({request})");
+            }
+        }
+
+        [TestCase("", ExpectedResult = "")]
+        [TestCase(null, ExpectedResult = "")]
+        [TestCase("{0} - {1} - {2} - {3} - {100} - {-100}", ExpectedResult = "Super Mario - Allure.NUnit.Examples.AllureStepNameInternalsTest+LocalTestClass - 12345 - {3} - {100} - {-100}")]
+        [TestCase("{id} - {0}", ExpectedResult = "12345 - Super Mario")]
+        [TestCase("{id} - {name} ({request})", ExpectedResult = "12345 - Super Mario (Allure.NUnit.Examples.AllureStepNameInternalsTest+LocalTestClass)")]
+        [TestCase("{id} - {request.TestField} - {request.TestProp}", ExpectedResult = "12345 - FieldValue - PropValue")]
+        [TestCase("{notExistingParameter} - {request.NotExistingField}", ExpectedResult = "{notExistingParameter} - {request.NotExistingField}")]
+        public string ApplyValues_Test(string stepNamePattern)
+        {
+            MethodBase methodBase = typeof(LocalTestClass).GetMethod(nameof(LocalTestClass.TestMethod))!;
+            object[] arguments = new object[]
+            {
+                "Super Mario", // name = {0}
+                new LocalTestClass // request = {1}
+                {
+                    TestField = "FieldValue",
+                    TestProp = "PropValue",
+                },
+                12345, // id = {2}
+            };
+
+            return AllureStepParameterHelper.ApplyValuesToPlaceholders(stepNamePattern, methodBase, arguments);
+        }
+    }
+}

--- a/Allure.NUnit/Core/Steps/AllureStepAspect.cs
+++ b/Allure.NUnit/Core/Steps/AllureStepAspect.cs
@@ -16,17 +16,13 @@ namespace NUnit.Allure.Core.Steps
             [Argument(Source.Arguments)] object[] arguments,
             [Argument(Source.Target)] Func<object[], object> method)
         {
-            var stepName = methodBase.GetCustomAttribute<AllureStepAttribute>().StepName;
+            var stepNamePattern = methodBase.GetCustomAttribute<AllureStepAttribute>().StepName;
 
-            for (var i = 0; i < arguments.Length; i++)
-            {
-              
-                stepName = stepName?.Replace("{" + i + "}", arguments[i]?.ToString() ?? "null");
-            }
+            var stepName = AllureStepParameterHelper.ApplyValuesToPlaceholders(stepNamePattern, methodBase, arguments);
 
             var stepResult = string.IsNullOrEmpty(stepName)
-                ? new StepResult {name = name, parameters = AllureStepParameterHelper.CreateParameters(arguments)}
-                : new StepResult {name = stepName, parameters = AllureStepParameterHelper.CreateParameters(arguments)};
+                ? new StepResult { name = name, parameters = AllureStepParameterHelper.CreateParameters(arguments) }
+                : new StepResult { name = stepName, parameters = AllureStepParameterHelper.CreateParameters(arguments) };
 
             object result;
             try

--- a/Allure.NUnit/Core/Steps/AllureStepParameterHelper.cs
+++ b/Allure.NUnit/Core/Steps/AllureStepParameterHelper.cs
@@ -1,14 +1,21 @@
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using Allure.Net.Commons;
+using NUnit.Allure.Attributes;
 
 namespace NUnit.Allure.Core.Steps
 {
     public static class AllureStepParameterHelper
     {
-        private const string Null = "null",
-            Unknown = "Unknown";
+        private const string Null = "null";
+        private const string Unknown = "Unknown";
+
+        private static readonly Regex argumentPattern = new Regex(@"\{(.*?)\}", RegexOptions.Compiled);
 
         public static List<Parameter> CreateParameters(IEnumerable<object> arguments)
             => arguments.Select(CreateParameters).ToList();
@@ -18,15 +25,109 @@ namespace NUnit.Allure.Core.Steps
             switch (argument)
             {
                 case null:
-                    return new Parameter {name = Unknown, value = Null};
+                    return new Parameter
+                    {
+                        name = Unknown,
+                        value = Null,
+                    };
                 case ICollection collection:
                     return new Parameter
                     {
                         name = argument.GetType().Name,
                         value = string.Join(", ", collection.Cast<object>().ToList())
                     };
-                default: return new Parameter {name = argument.GetType().Name, value = argument.ToString()};
+                default:
+                    return new Parameter
+                    {
+                        name = argument.GetType().Name,
+                        value = argument.ToString(),
+                    };
             }
+        }
+
+        public static string ApplyValuesToPlaceholders(string stepName, MethodBase methodBase, object[] arguments)
+        {
+            if (string.IsNullOrWhiteSpace(stepName))
+            {
+                return "";
+            }
+
+            var parameters = methodBase.GetParameters();
+            var parameterIndex = parameters.ToDictionary(x => x.Name);
+
+            var matches = argumentPattern.Matches(stepName);
+            foreach (Match match in matches)
+            {
+                var pattern = match.Groups[1].Value;
+
+                if (int.TryParse(pattern, out var index) &&
+                    TryGetValue(arguments, index, out var value1)
+                )
+                {
+                    //!_! apply {paramPosition} placeholder
+                    stepName = stepName?.Replace(match.Value, value1?.ToString() ?? "null");
+                }
+                else if (parameterIndex.TryGetValue(pattern, out var parameter1) &&
+                    TryGetValue(arguments, parameter1.Position, out var value2)
+                )
+                {
+                    //!_! apply {paramName} placeholder
+                    stepName = stepName?.Replace(match.Value, value2?.ToString() ?? "null");
+                }
+                else if (TrySplit(pattern, '.', out var parts) &&
+                    parts.Length == 2 &&
+                    parameterIndex.TryGetValue(parts[0], out var parameter2) &&
+                    TryGetValue(arguments[parameter2.Position], parts[1], out var value3)
+                )
+                {
+                    //!_! apply {paramName.fieldOrProperty} placeholder
+                    stepName = stepName?.Replace(match.Value, value3);
+                }
+            }
+
+            return stepName;
+        }
+
+        private static bool TrySplit(string s, char separator, out string[] parts)
+        {
+            parts = s.Split(separator);
+            return parts.Length > 0;
+        }
+
+        private static bool TryGetValue(object[] array, int index, out object value)
+        {
+            if (index < 0 || index >= array.Length)
+            {
+                value = null;
+                return false;
+            }
+
+            value = array[index];
+            return true;
+        }
+
+        /// <summary> Getting the value of field or property </summary>
+        private static bool TryGetValue(object obj, string name, out string value)
+        {
+            value = Unknown;
+            if (obj == null) return false;
+
+            var field = obj.GetType()?.GetField(name);
+            if (field != null)
+            {
+                value = field.GetValue(obj)?.ToString() ?? Null;
+                return true;
+            }
+
+            var prop = obj.GetType()?.GetProperty(name);
+            if (prop != null)
+            {
+                value = prop.GetValue(obj, null)?.ToString() ?? Null;
+                return true;
+            }
+
+            value = Unknown;
+            return false;
         }
     }
 }


### PR DESCRIPTION
This pull request provides the ability to use `"{paramName}"` and `"{paramName.FieldOrProperty}"` placeholders in `[AllureStep]` attribute.

Like this
```csharp
[AllureStep("Login with credentials: {username} / {password}.")]
public void LoginWith(string username, string password)
{
    ...
}
```
and even like this
```csharp
[AllureStep("Login with credentials: {user.Name} / {user.Password}.")]
public void LoginWith(User user)
{
    ...
}
```

New approach can still be combined with position-based
```csharp
[AllureStep("Check if user has role; RoleId: {0}; UserName: {user.Name}.")]
public void CheckRole(int roleId, User user)
{
    ...
}
```

I've provided some unit tests for this (see `AllureStepNameInternalsTest`)