### PR TITLE
[NUnit] Fix async behaviour in [AllureStep] aspect + Allow '{obj.prop}' placeholders in [AllureStep] step name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,3 +265,5 @@ __pycache__/
 .DS_Store
 *mono_crash*
 /.vscode
+
+.editorconfig

--- a/Allure.NUnit.Examples/AllureStepNameInternalsTest.cs
+++ b/Allure.NUnit.Examples/AllureStepNameInternalsTest.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Allure.Attributes;
+using NUnit.Allure.Core.Steps;
+using NUnit.Framework;
+
+namespace Allure.NUnit.Examples
+{
+    [AllureSuite("Tests - Step Names")]
+    public class AllureStepNameInternalsTest : BaseTest
+    {
+        internal class LocalTestClass
+        {
+            public string TestField;
+            public string TestProp { get; set; }
+
+            public void TestMethod(string name, LocalTestClass request, int id)
+            {
+                Console.WriteLine($"{id} - {name} ({request})");
+            }
+        }
+
+        [TestCase("", ExpectedResult = "")]
+        [TestCase(null, ExpectedResult = "")]
+        [TestCase("{0} - {1} - {2} - {3} - {100} - {-100}", ExpectedResult = "Super Mario - Allure.NUnit.Examples.AllureStepNameInternalsTest+LocalTestClass - 12345 - {3} - {100} - {-100}")]
+        [TestCase("{id} - {0}", ExpectedResult = "12345 - Super Mario")]
+        [TestCase("{id} - {name} ({request})", ExpectedResult = "12345 - Super Mario (Allure.NUnit.Examples.AllureStepNameInternalsTest+LocalTestClass)")]
+        [TestCase("{id} - {request.TestField} - {request.TestProp}", ExpectedResult = "12345 - FieldValue - PropValue")]
+        [TestCase("{notExistingParameter} - {request.NotExistingField}", ExpectedResult = "{notExistingParameter} - {request.NotExistingField}")]
+        public string ApplyValues_Test(string stepNamePattern)
+        {
+            MethodBase methodBase = typeof(LocalTestClass).GetMethod(nameof(LocalTestClass.TestMethod))!;
+            object[] arguments = new object[]
+            {
+                "Super Mario", // name = {0}
+                new LocalTestClass // request = {1}
+                {
+                    TestField = "FieldValue",
+                    TestProp = "PropValue",
+                },
+                12345, // id = {2}
+            };
+
+            return AllureStepParameterHelper.GetStepName(stepNamePattern, methodBase, arguments);
+        }
+
+        [TestCase("", ExpectedResult = "")]
+        [TestCase(null, ExpectedResult = "")]
+        [TestCase("{0} - {1} - {2} - {3} - {100} - {-100}", ExpectedResult = "Super Mario - null - 12345 - {3} - {100} - {-100}")]
+        [TestCase("{id} - {0}", ExpectedResult = "12345 - Super Mario")]
+        [TestCase("{id} - {name} ({request})", ExpectedResult = "12345 - Super Mario (null)")]
+        [TestCase("{id} - {request.TestField} - {request.TestProp}", ExpectedResult = "12345 - {request.TestField} - {request.TestProp}")]
+        [TestCase("{notExistingParameter} - {request.NotExistingField}", ExpectedResult = "{notExistingParameter} - {request.NotExistingField}")]
+        public string ApplyNullValues_Test(string stepNamePattern)
+        {
+            MethodBase methodBase = typeof(LocalTestClass).GetMethod(nameof(LocalTestClass.TestMethod))!;
+            object[] arguments = new object[]
+            {
+                "Super Mario", // name = {0}
+                null,
+                12345, // id = {2}
+            };
+
+            return AllureStepParameterHelper.GetStepName(stepNamePattern, methodBase, arguments);
+        }
+    }
+}

--- a/Allure.NUnit/Core/Steps/AllureStepAspect.cs
+++ b/Allure.NUnit/Core/Steps/AllureStepAspect.cs
@@ -19,107 +19,68 @@ namespace NUnit.Allure.Core.Steps
 
         private static readonly MethodInfo SyncHandler =
             typeof(AllureStepAspect).GetMethod(nameof(WrapSync), BindingFlags.NonPublic | BindingFlags.Static);
-        
-        private static readonly Type _voidTaskResult = Type.GetType("System.Threading.Tasks.VoidTaskResult");
+
+        private static readonly MethodInfo SyncVoidHandler =
+            typeof(AllureStepAspect).GetMethod(nameof(WrapSyncVoid), BindingFlags.NonPublic | BindingFlags.Static);
+
+        private static readonly Type _typeVoidTaskResult = Type.GetType("System.Threading.Tasks.VoidTaskResult");
+        private static readonly Type _typeVoid = typeof(void);
+        private static readonly Type _typeTask = typeof(Task);
 
         [Advice(Kind.Around, Targets = Target.Method)]
-        public object Around([Argument(Source.Name)] string name,
+        public object Around(
+            [Argument(Source.Name)] string name,
             [Argument(Source.Arguments)] object[] args,
             [Argument(Source.Target)] Func<object[], object> target,
             [Argument(Source.Metadata)] MethodBase metadata,
-            [Argument(Source.ReturnType)] Type returnType)
+            [Argument(Source.ReturnType)] Type returnType
+        )
         {
-            object executionResult;
-            var stepName = metadata.GetCustomAttribute<AllureStepBaseAttribute>().Name ?? name;
+            var stepNamePattern = metadata.GetCustomAttribute<AllureStepBaseAttribute>().Name ?? name;
+            var stepName = AllureStepParameterHelper.GetStepName(stepNamePattern, metadata, args);
+            var stepParameters = GetStepParameters(metadata, args);
 
-            for (var i = 0; i < args.Length; i++)
+            if (_typeTask.IsAssignableFrom(returnType))
             {
-                stepName = stepName?.Replace("{" + i + "}", args[i]?.ToString() ?? "null");
-                if (stepName.Contains("{" + i + "}"))
-                {
-                    // TODO: provide error description link
-                    Console.Error.WriteLine("Indexed step arguments is obsolete. Use named arguments instead. ({0} -> {argumentName}) See: LINK_TO_ERROR");
-                }
+                var syncResultType = returnType.IsConstructedGenericType
+                    ? returnType.GenericTypeArguments[0]
+                    : _typeVoidTaskResult;
+                return AsyncHandler.MakeGenericMethod(syncResultType)
+                    .Invoke(this, new object[] { target, args, metadata, stepName, stepParameters });
             }
-            
-            stepName = metadata.GetParameters().Aggregate(stepName,
-                (current, parameterInfo) => current?.Replace("{" + parameterInfo.Name + "}",
-                    args[parameterInfo.Position]?.ToString() ?? "null"));
-
-            var stepResult = string.IsNullOrEmpty(stepName)
-                ? new StepResult {name = name, parameters = AllureStepParameterHelper.CreateParameters(args)}
-                : new StepResult {name = stepName, parameters = AllureStepParameterHelper.CreateParameters(args)};
-
-            var stepParameters = metadata.GetParameters()
-                .Select(x => (
-                    name: x.GetCustomAttribute<NameAttribute>()?.Name ?? x.Name,
-                    skip: x.GetCustomAttribute<SkipAttribute>() != null))
-                .Zip(args, (parameter, value) => parameter.skip
-                    ? null
-                    : new Parameter
-                    {
-                        name = parameter.name,
-                        value = value?.ToString()
-                    })
-                .Where(x => x != null)
-                .ToList();
-
-            try
+            else if (_typeVoid.IsAssignableFrom(returnType))
             {
-                StartFixture(metadata, stepName);
-                StartStep(metadata, stepName, stepParameters);
-
-                executionResult = GetStepExecutionResult(returnType, target, args);
-                if (executionResult != null && typeof(Task).IsAssignableFrom(executionResult.GetType()))
-                {
-                    ((Task)executionResult).ContinueWith((task) =>
-                    {
-                        if (task.IsFaulted)
-                        {
-                            var e = task.Exception;
-                            ThrowStep(metadata, e?.InnerException);
-                            ThrowFixture(metadata, e?.InnerException);
-                        }
-                        else
-                        {
-                            PassStep(metadata);
-                            PassFixture(metadata);
-                        }
-                    });
-                }
-                else
-                {
-                    PassStep(metadata);
-                    PassFixture(metadata);
-                }
+                return SyncVoidHandler
+                    .Invoke(this, new object[] { target, args, metadata, stepName, stepParameters });
             }
-            catch (Exception e)
+            else
             {
-                ThrowStep(metadata, e);
-                ThrowFixture(metadata, e);
-                throw;
+                return SyncHandler.MakeGenericMethod(returnType)
+                    .Invoke(this, new object[] { target, args, metadata, stepName, stepParameters });
             }
-
-            return executionResult;
         }
-        
-        private static void StartStep(MethodBase metadata, string stepName, List<Parameter> stepParameters)
+
+        // ------------------------------
+
+        private static string StartStep(MethodBase metadata, string stepName, List<Parameter> stepParameters)
         {
             if (metadata.GetCustomAttribute<AllureStepAttribute>() != null)
             {
-                StepsHelper.StartStep(stepName, step => step.parameters = stepParameters);
+                return StepsHelper.StartStep(stepName, step => step.parameters = stepParameters);
             }
+
+            return null;
         }
-        
-        private static void PassStep(MethodBase metadata)
+
+        private static void PassStep(string uuid, MethodBase metadata)
         {
             if (metadata.GetCustomAttribute<AllureStepAttribute>() != null)
             {
-                StepsHelper.PassStep();
+                StepsHelper.PassStep(uuid);
             }
         }
-        
-        private static void ThrowStep(MethodBase metadata, Exception e)
+
+        private static void ThrowStep(string uuid, MethodBase metadata, Exception e)
         {
             if (metadata.GetCustomAttribute<AllureStepAttribute>() != null)
             {
@@ -128,18 +89,18 @@ namespace NUnit.Allure.Core.Steps
                     message = e.Message,
                     trace = e.StackTrace
                 };
-                
+
                 if (e is NUnitException || e is AssertionException)
                 {
-                    StepsHelper.FailStep(result => result.statusDetails = exceptionStatusDetails);
+                    StepsHelper.FailStep(uuid, result => result.statusDetails = exceptionStatusDetails);
                 }
                 else
                 {
-                    StepsHelper.BrokeStep(result => result.statusDetails = exceptionStatusDetails);
+                    StepsHelper.BrokeStep(uuid, result => result.statusDetails = exceptionStatusDetails);
                 }
             }
         }
-        
+
         private static void StartFixture(MethodBase metadata, string stepName)
         {
             if (metadata.GetCustomAttribute<AllureBeforeAttribute>() != null)
@@ -152,7 +113,7 @@ namespace NUnit.Allure.Core.Steps
                 StepsHelper.StartAfterFixture(stepName);
             }
         }
-        
+
         private static void PassFixture(MethodBase metadata)
         {
             if (metadata.GetCustomAttribute<AllureBeforeAttribute>() != null ||
@@ -161,7 +122,7 @@ namespace NUnit.Allure.Core.Steps
                 StepsHelper.StopFixtureSuppressTestCase(result => result.status = Status.passed);
             }
         }
-        
+
         private static void ThrowFixture(MethodBase metadata, Exception e)
         {
             if (metadata.GetCustomAttribute<AllureBeforeAttribute>() != null ||
@@ -192,34 +153,120 @@ namespace NUnit.Allure.Core.Steps
             }
         }
 
-        private object GetStepExecutionResult(Type returnType, Func<object[], object> target, object[] args)
+        // ------------------------------
+
+        private List<Parameter> GetStepParameters(MethodBase metadata, object[] args)
         {
-            if (typeof(Task).IsAssignableFrom(returnType))
-            {
-                var syncResultType = returnType.IsConstructedGenericType
-                    ? returnType.GenericTypeArguments[0]
-                    : _voidTaskResult;
-                return AsyncHandler.MakeGenericMethod(syncResultType)
-                    .Invoke(this, new object[] { target, args });
-            }
-
-            if (typeof(void).IsAssignableFrom(returnType))
-            {
-                return target(args);
-            }
-
-            return SyncHandler.MakeGenericMethod(returnType)
-                .Invoke(this, new object[] { target, args });
+            return metadata.GetParameters()
+                .Select(x => (
+                    name: x.GetCustomAttribute<NameAttribute>()?.Name ?? x.Name,
+                    skip: x.GetCustomAttribute<SkipAttribute>() != null))
+                .Zip(args,
+                    (parameter, value) => parameter.skip
+                        ? null
+                        : new Parameter
+                        {
+                            name = parameter.name,
+                            value = value?.ToString()
+                        })
+                .Where(x => x != null)
+                .ToList();
         }
 
-        private static T WrapSync<T>(Func<object[], object> target, object[] args)
+        // ------------------------------
+
+        private static string BeforeTargetInvoke(MethodBase metadata, string stepName, List<Parameter> stepParameters)
         {
-            return (T)target(args);
+            StartFixture(metadata, stepName);
+            var stepUuid = StartStep(metadata, stepName, stepParameters);
+            return stepUuid;
         }
 
-        private static async Task<T> WrapAsync<T>(Func<object[], object> target, object[] args)
+        private static void AfterTargetInvoke(string stepUuid, MethodBase metadata)
         {
-            return await (Task<T>)target(args);
+            PassStep(stepUuid, metadata);
+            PassFixture(metadata);
+        }
+
+        private static void OnTargetInvokeException(string stepUuid, MethodBase metadata, Exception e)
+        {
+            ThrowStep(stepUuid, metadata, e);
+            ThrowFixture(metadata, e);
+        }
+
+        // ------------------------------
+
+        private static T WrapSync<T>(
+            Func<object[], object> target,
+            object[] args,
+            MethodBase metadata,
+            string stepName,
+            List<Parameter> stepParameters
+        )
+        {
+            string stepUuid = null;
+
+            try
+            {
+                stepUuid = BeforeTargetInvoke(metadata, stepName, stepParameters);
+                var result = (T)target(args);
+                AfterTargetInvoke(stepUuid, metadata);
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                OnTargetInvokeException(stepUuid, metadata, e);
+                throw;
+            }
+        }
+
+        private static void WrapSyncVoid(
+            Func<object[], object> target,
+            object[] args,
+            MethodBase metadata,
+            string stepName,
+            List<Parameter> stepParameters
+        )
+        {
+            string stepUuid = null;
+
+            try
+            {
+                stepUuid = BeforeTargetInvoke(metadata, stepName, stepParameters);
+                target(args);
+                AfterTargetInvoke(stepUuid, metadata);
+            }
+            catch (Exception e)
+            {
+                OnTargetInvokeException(stepUuid, metadata, e);
+                throw;
+            }
+        }
+
+        private static async Task<T> WrapAsync<T>(
+            Func<object[], object> target,
+            object[] args,
+            MethodBase metadata,
+            string stepName,
+            List<Parameter> stepParameters
+        )
+        {
+            string stepUuid = null;
+
+            try
+            {
+                stepUuid = BeforeTargetInvoke(metadata, stepName, stepParameters);
+                var result = await ((Task<T>)target(args)).ConfigureAwait(false);
+                AfterTargetInvoke(stepUuid, metadata);
+
+                return result;
+            }
+            catch (Exception e)
+            {
+                OnTargetInvokeException(stepUuid, metadata, e);
+                throw;
+            }
         }
     }
 }

--- a/Allure.NUnit/Core/Steps/AllureStepParameterHelper.cs
+++ b/Allure.NUnit/Core/Steps/AllureStepParameterHelper.cs
@@ -1,14 +1,19 @@
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
 using Allure.Net.Commons;
 
 namespace NUnit.Allure.Core.Steps
 {
     public static class AllureStepParameterHelper
     {
-        private const string Null = "null",
-            Unknown = "Unknown";
+        private const string Null = "null";
+        private const string Unknown = "Unknown";
+
+        private static readonly Regex argumentPattern = new Regex(@"\{(.*?)\}", RegexOptions.Compiled);
 
         public static List<Parameter> CreateParameters(IEnumerable<object> arguments)
             => arguments.Select(CreateParameters).ToList();
@@ -18,15 +23,123 @@ namespace NUnit.Allure.Core.Steps
             switch (argument)
             {
                 case null:
-                    return new Parameter {name = Unknown, value = Null};
+                    return new Parameter
+                    {
+                        name = Unknown,
+                        value = Null,
+                    };
                 case ICollection collection:
                     return new Parameter
                     {
                         name = argument.GetType().Name,
-                        value = string.Join(", ", collection.Cast<object>().ToList())
+                        value = string.Join(", ", collection.Cast<object>().ToList()),
                     };
-                default: return new Parameter {name = argument.GetType().Name, value = argument.ToString()};
+                default:
+                    return new Parameter
+                    {
+                        name = argument.GetType().Name,
+                        value = argument.ToString(),
+                    };
             }
+        }
+
+        public static string GetStepName(string stepName, MethodBase methodBase, object[] arguments)
+        {
+            var initialStepName = stepName;
+
+            if (string.IsNullOrWhiteSpace(stepName))
+            {
+                return "";
+            }
+
+            var showIndexWarning = false;
+
+            var parameters = methodBase.GetParameters();
+            var parameterIndex = parameters.ToDictionary(x => x.Name);
+
+            var matches = argumentPattern.Matches(stepName);
+            foreach (Match match in matches)
+            {
+                var pattern = match.Groups[1].Value;
+
+                if (int.TryParse(pattern, out var index) &&
+                    TryGetValue(arguments, index, out var value1)
+                )
+                {
+                    //!_! apply {paramIndex} placeholder - i.e. {0}, {1}, ...
+                    stepName = stepName?.Replace(match.Value, value1?.ToString() ?? "null");
+                    showIndexWarning = true;
+                }
+                else if (parameterIndex.TryGetValue(pattern, out var parameter1) &&
+                    TryGetValue(arguments, parameter1.Position, out var value2)
+                )
+                {
+                    //!_! apply {paramName} placeholder - i.e. {requestId}, {isDelete}, ...
+                    stepName = stepName?.Replace(match.Value, value2?.ToString() ?? "null");
+                }
+                else if (TrySplit(pattern, '.', out var parts) &&
+                    parts.Length == 2 &&
+                    parameterIndex.TryGetValue(parts[0], out var parameter2) &&
+                    TryGetValue(arguments[parameter2.Position], parts[1], out var value3)
+                )
+                {
+                    //!_! apply {paramName.fieldOrProperty} placeholder - i.e. {request.Id}, ...
+                    stepName = stepName?.Replace(match.Value, value3);
+                }
+            }
+
+            if (showIndexWarning)
+            {
+                // TODO: provide error description link
+                Console.Error.WriteLine(
+                    "Indexed step arguments are obsolete. " +
+                    $"Use named arguments in step name '{initialStepName}' instead."
+                );
+            }
+
+            return stepName;
+        }
+
+        private static bool TrySplit(string s, char separator, out string[] parts)
+        {
+            parts = s.Split(separator);
+            return parts.Length > 0;
+        }
+
+        private static bool TryGetValue(object[] array, int index, out object value)
+        {
+            if (index < 0 || index >= array.Length)
+            {
+                value = null;
+                return false;
+            }
+
+            value = array[index];
+            return true;
+        }
+
+        /// <summary> Getting the value of field or property </summary>
+        private static bool TryGetValue(object obj, string name, out string value)
+        {
+            value = Unknown;
+            if (obj == null) return false;
+
+            var field = obj.GetType()?.GetField(name);
+            if (field != null)
+            {
+                value = field.GetValue(obj)?.ToString() ?? Null;
+                return true;
+            }
+
+            var prop = obj.GetType()?.GetProperty(name);
+            if (prop != null)
+            {
+                value = prop.GetValue(obj, null)?.ToString() ?? Null;
+                return true;
+            }
+
+            value = Unknown;
+            return false;
         }
     }
 }


### PR DESCRIPTION
This pull request:

1) additionally fixes race conditions in async part of NUnit AllureStep aspect (it's the continuation of PR #314),

2) provides the ability to use `"{obj.prop}"` placeholders in `[AllureStep]` step name attribute.

```csharp
[AllureStep("Login with credentials: {user.Name} / {user.Password}.")]
public void LoginWith(User user)
{
    ...
}
```

This approach can still be combined with index-based placeholders

```csharp
[AllureStep("Check if user has role; RoleId: {0}; UserName: {user.Name}.")]
public void CheckRole(int roleId, User user)
{
    ...
}
```

I've provided some unit tests for this (see `AllureStepNameInternalsTest`)

I've tried to make this PR to main-branch, but it seems like `2.9.4-preview` branch is way more up to date.