### PR TITLE
Add an ability to create custom formatter for step parameters

### DIFF
--- a/Allure.NUnit.Examples/AllureStepArgumentFormattingTest.cs
+++ b/Allure.NUnit.Examples/AllureStepArgumentFormattingTest.cs
@@ -1,0 +1,40 @@
+using System;
+using Allure.Net.Commons;
+using NUnit.Allure.Attributes;
+using NUnit.Framework;
+
+namespace Allure.NUnit.Examples;
+
+[AllureSuite("Tests - Steps")]
+public class AllureStepArgumentFormattingTest : BaseTest
+{
+    [AllureStep("Step with params #{0}")]
+    private static void StepWithCustomClassParams(CustomClass firstParam)
+    {
+        Console.WriteLine(firstParam);
+    }
+
+    [OneTimeSetUp]
+    public static void OneTimeSetUp()
+    {
+        AllureLifecycle.Instance.AddTypeFormatter(new CustomClassFormatter());
+    }
+
+    [Test]
+    [AllureName("Test with custom formatting for step argument")]
+    public void StepWithCustomParamTest()
+    {
+        StepWithCustomClassParams(new CustomClass { I = 10, S = "string" });
+    }
+
+    private class CustomClass
+    {
+        public int I { get; init; }
+        public string S { get; init; }
+    }
+
+    private class CustomClassFormatter : TypeFormatter<CustomClass>
+    {
+        public override string Format(CustomClass value) => $"___{value.S} + {value.I}___";
+    }
+}

--- a/Allure.Net.Commons/AllureLifecycle.cs
+++ b/Allure.Net.Commons/AllureLifecycle.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -15,6 +17,11 @@ namespace Allure.Net.Commons
 {
     public class AllureLifecycle
     {
+        private readonly Dictionary<Type, ITypeFormatter> typeFormatters = new();
+
+        public IReadOnlyDictionary<Type, ITypeFormatter> TypeFormatters =>
+            new ReadOnlyDictionary<Type, ITypeFormatter>(typeFormatters);
+
         private static readonly object Lockobj = new();
         private static AllureLifecycle instance;
         private readonly AllureStorage storage;
@@ -59,6 +66,12 @@ namespace Allure.Net.Commons
                 return instance;
             }
         }
+
+        public void AddTypeFormatter<T>(TypeFormatter<T> typeFormatter) =>
+            AddTypeFormatterImpl(typeof(T), typeFormatter);
+
+        private void AddTypeFormatterImpl(Type type, ITypeFormatter formatter) =>
+            typeFormatters[type] = formatter;
 
         #region TestContainer
 

--- a/Allure.Net.Commons/TypeFormatter.cs
+++ b/Allure.Net.Commons/TypeFormatter.cs
@@ -1,0 +1,16 @@
+namespace Allure.Net.Commons;
+
+public interface ITypeFormatter
+{
+    string Format(object value);
+}
+
+public abstract class TypeFormatter<T> : ITypeFormatter
+{
+    public abstract string Format(T value);
+
+    string ITypeFormatter.Format(object value)
+    {
+        return Format((T)value);
+    }
+}


### PR DESCRIPTION
### Context

Provide ability to specify formatter for arbitrary type, then pass parameters of this type to step and step name will be formatted with custom formatting instead of .ToString()

It decouples ToString() implementation from allure step presentation


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
