### PR TITLE
Remove ConfigureAwait(false) in WrapAsync to avoid SynchronizationContext switch

### DIFF
--- a/Allure.NUnit/Core/Steps/AllureStepAspect.cs
+++ b/Allure.NUnit/Core/Steps/AllureStepAspect.cs
@@ -257,7 +257,7 @@ namespace NUnit.Allure.Core.Steps
             try
             {
                 stepUuid = BeforeTargetInvoke(metadata, stepName, stepParameters);
-                var result = await ((Task<T>)target(args)).ConfigureAwait(false);
+                var result = await ((Task<T>)target(args));
                 AfterTargetInvoke(stepUuid, metadata);
 
                 return result;


### PR DESCRIPTION
Remove ConfigureAwait(false) to avoid switching into default SynchronizationContext.

### Context
We have SpecFlow + NUnit + Allure libs in the same project.
SpecFlow uses it's own SynchronizationContext. Async code that executes inside methods that marked as [AllureStep] will always switch into default SynchronizationContext.
#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
