### PR TITLE
Add an ability to save OneTimeSetUp step results

### DIFF
--- a/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
+++ b/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using Allure.NUnit.Examples.CommonSteps;
+using NUnit.Allure.Attributes;
+using NUnit.Framework;
+
+namespace Allure.NUnit.Examples
+{
+	[AllureSuite("Tests - Async OneTime SetUp")]
+	[Parallelizable(ParallelScope.All)]
+	public class AllureAsyncOneTimeSetUpTests: BaseTest
+	{
+		[OneTimeSetUp]
+		public async Task OneTimeSetUp()
+		{
+			await AsyncStepsExamples.PrepareDough();
+			await AsyncStepsExamples.CookPizza();
+			await AsyncStepsExamples.CookPizza();
+			await AsyncStepsExamples.CookPizza();
+		}
+
+		[Test]
+		[AllureName("Test1")]
+		public async Task Test1()
+		{
+			await AsyncStepsExamples.DeliverPizza();
+			await AsyncStepsExamples.Pay();
+		}
+		
+		[Test]
+		[AllureName("Test2")]
+		public async Task Test2()
+		{
+			await AsyncStepsExamples.DeliverPizza();
+		}
+	}
+}

--- a/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
+++ b/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
@@ -18,6 +18,12 @@ namespace Allure.NUnit.Examples
 			await AsyncStepsExamples.CookPizza();
 		}
 
+		[SetUp]
+		public async Task SetUp()
+		{
+			await AsyncStepsExamples.PrepareDough();
+		}
+
 		[Test]
 		[AllureName("Test1")]
 		public async Task Test1()

--- a/Allure.NUnit.Examples/AllureAsyncStepTest.cs
+++ b/Allure.NUnit.Examples/AllureAsyncStepTest.cs
@@ -1,29 +1,9 @@
-using System;
 using System.Threading.Tasks;
+using Allure.NUnit.Examples.CommonSteps;
 using NUnit.Allure.Attributes;
 using NUnit.Framework;
 
 namespace Allure.NUnit.Examples;
-
-public static class AsyncStepsExamples
-{
-    [AllureStep("Prepare dough")]
-    public static async Task PrepareDough()
-    {
-        await AsyncMethod($"Step {nameof(PrepareDough)}");
-    }
-
-    [AllureStep("Cook pizza")]
-    public static async Task CookPizza()
-    {
-        await AsyncMethod($"Step {nameof(CookPizza)}");
-    }
-    private static async Task AsyncMethod(string message)
-    {
-        await Task.Delay(3);
-        Console.WriteLine($"{message}");
-    }
-}
 
 [AllureSuite("Tests - Async Steps")]
 public class AllureAsyncStepTest : BaseTest

--- a/Allure.NUnit.Examples/CommonSteps/AsyncStepsExamples.cs
+++ b/Allure.NUnit.Examples/CommonSteps/AsyncStepsExamples.cs
@@ -6,6 +6,8 @@ namespace Allure.NUnit.Examples.CommonSteps;
 
 public static class AsyncStepsExamples
 {
+    private static readonly Random Random = new();
+    
     [AllureStep("Prepare dough")]
     public static async Task PrepareDough()
     {
@@ -31,7 +33,8 @@ public static class AsyncStepsExamples
     }
     private static async Task AsyncMethod(string message)
     {
-        await Task.Delay(3);
+        var delay = Random.Next(50, 200);
+        await Task.Delay(delay);
         Console.WriteLine($"{message}");
     }
 }

--- a/Allure.NUnit.Examples/CommonSteps/AsyncStepsExamples.cs
+++ b/Allure.NUnit.Examples/CommonSteps/AsyncStepsExamples.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Allure.Attributes;
+
+namespace Allure.NUnit.Examples.CommonSteps;
+
+public static class AsyncStepsExamples
+{
+    [AllureStep("Prepare dough")]
+    public static async Task PrepareDough()
+    {
+        await AsyncMethod($"Step {nameof(PrepareDough)}");
+    }
+
+    [AllureStep("Cook pizza")]
+    public static async Task CookPizza()
+    {
+        await AsyncMethod($"Step {nameof(CookPizza)}");
+    }
+
+    [AllureStep("Deliver")]
+    public static async Task DeliverPizza()
+    {
+        await AsyncMethod($"Step {nameof(DeliverPizza)}");
+    }
+    
+    [AllureStep("Pay")]
+    public static async Task Pay()
+    {
+        await AsyncMethod($"Step {nameof(Pay)}");
+    }
+    private static async Task AsyncMethod(string message)
+    {
+        await Task.Delay(3);
+        Console.WriteLine($"{message}");
+    }
+}

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -240,7 +240,7 @@ namespace NUnit.Allure.Core
 
             fixtureResult = testFixture.Properties.Get("OneTimeSetUpResult") as FixtureResult;
 
-            if (fixtureResult != null)
+            if (fixtureResult != null && fixtureResult.steps.Any())
             {
                 AllureLifecycle.UpdateTestContainer(TestResultContainer.uuid, container =>
                 {

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -37,11 +37,9 @@ namespace NUnit.Allure.Core
         internal void StartTestContainer()
         {
             StepsHelper.TestResultAccessor = this;
-            var testFixture = GetTestFixture(_test);
-            _containerGuid = string.Concat(Guid.NewGuid().ToString(), "-tc-", testFixture.Id);
             TestResultContainer = new TestResultContainer
             {
-                uuid = _containerGuid,
+                uuid = ContainerId,
                 name = _test.FullName
             };
             AllureLifecycle.StartTestContainer(TestResultContainer);
@@ -65,7 +63,7 @@ namespace NUnit.Allure.Core
                     Label.TestClass(_test.ClassName?.Substring(_test.ClassName.LastIndexOf('.') + 1))
                 }
             };
-            AllureLifecycle.StartTestCase(_containerGuid, TestResult);
+            AllureLifecycle.StartTestCase(ContainerId, TestResult);
         }
 
         private TestFixture GetTestFixture(ITest test)
@@ -112,8 +110,8 @@ namespace NUnit.Allure.Core
 
         internal void StopTestContainer()
         {
-            AllureLifecycle.StopTestContainer(_containerGuid);
-            AllureLifecycle.WriteTestContainer(_containerGuid);
+            AllureLifecycle.StopTestContainer(ContainerId);
+            AllureLifecycle.WriteTestContainer(ContainerId);
         }
 
         public static Status GetNUnitStatus()
@@ -156,7 +154,6 @@ namespace NUnit.Allure.Core
 
             return Status.passed;
         }
-
 
         private void UpdateTestDataFromAttributes()
         {
@@ -206,6 +203,50 @@ namespace NUnit.Allure.Core
         public void WrapInStep(Action action, string stepName = "")
         {
             AllureLifecycle.WrapInStep(action, stepName);
+        }
+
+        private string ContainerId => $"tc-{_test.Id}";
+        
+        public void SaveOneTimeResultToContext()
+        {
+            var currentResult = TestExecutionContext.CurrentContext.CurrentResult;
+
+            if (!string.IsNullOrEmpty(currentResult.Output))
+            {
+                AllureLifecycle.Instance.AddAttachment("Console Output", "text/plain",
+                    Encoding.UTF8.GetBytes(currentResult.Output), ".txt");    
+            }
+
+            FixtureResult fixtureResult = null;
+            AllureLifecycle.Instance.UpdateFixture(fr =>
+            {
+                fr.name = "OneTimeSetUp";
+                fr.status = fr.steps.SelectMany(s => s.steps)
+                    .All(s => s.status == Status.passed)
+                    ? Status.passed
+                    : Status.failed;
+
+                fixtureResult = fr;
+            });
+            
+            var testFixture = GetTestFixture(TestExecutionContext.CurrentContext.CurrentTest);
+            testFixture.Properties.Set("OneTimeSetUpResult", fixtureResult);
+        }
+        
+        public void AddOneTimeSetupResult()
+        {
+            var testFixture = GetTestFixture(TestExecutionContext.CurrentContext.CurrentTest);
+            FixtureResult fixtureResult = null;
+
+            fixtureResult = testFixture.Properties.Get("OneTimeSetUpResult") as FixtureResult;
+
+            if (fixtureResult != null)
+            {
+                AllureLifecycle.UpdateTestContainer(TestResultContainer.uuid, container =>
+                {
+                    container.befores.Add(fixtureResult);
+                });
+            }
         }
     }
 }

--- a/Allure.Net.Commons/Storage/AllureStorage.cs
+++ b/Allure.Net.Commons/Storage/AllureStorage.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
 
 namespace Allure.Net.Commons.Storage
 {
@@ -35,6 +33,7 @@ namespace Allure.Net.Commons.Storage
         public void ClearStepContext()
         {
             Steps.Clear();
+            stepContext.TryRemove(AllureLifecycle.CurrentTestIdGetter(), out _);
         }
 
         public void StartStep(string uuid)


### PR DESCRIPTION
Fixes #286

### Context
Previously, we couldn't use methods with AllureStepAttribute inside OneTimeSetUp because it raised an exception.
We extended AllureNUnitAttribute to save result when TestFixture starts. And then put it to TestResults for each test in Suite.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
