### PR TITLE
Add an ability to use multiple suite names

### DIFF
--- a/Allure.NUnit/Attributes/AllureSuitesAttribute.cs
+++ b/Allure.NUnit/Attributes/AllureSuitesAttribute.cs
@@ -1,0 +1,26 @@
+using System;
+using Allure.Net.Commons;
+
+namespace NUnit.Allure.Attributes
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+    public class AllureSuitesAttribute : AllureTestCaseAttribute
+    {
+        public AllureSuitesAttribute(params string[] suites)
+        {
+            Suites = suites;
+            Prefix = "Suite";
+        }
+		
+        private string[] Suites { get; }
+        private string Prefix { get; }
+
+        public override void UpdateTestResult(TestResult testResult)
+        {
+            for (var i = 0; i < Suites.Length; i++)
+            {
+                testResult.labels.Add(new Label{name = $"{Prefix}{i + 1}", value = Suites[i]});
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Context
We used AllureParentSuite, AllureSuite and AllureSubSuite and it was inconvenient for complex hierarchy
```
    [AllureParentSuite("ParentSuite")]
    [AllureSuite("Suite")]
    [AllureSubSuite("SubSuite")]
    [AllureLabel("SubSubSuite","SubSubSuite")]
```
Instead of it now we can use 
```
[AllureSuites("ParentSuite", "Suite", "SubSuite", "SubSubSuite")]
```
It will be mapped to labels for the example above: 
`Suite1=ParentSuite, Suite2 = Suite, Suite3=SubSuite, Suite4=SubSubSuite`

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
