### PR TITLE
NUnit: Fix inconsistent one-time fixtures behavior (fixes #286, #374 and #375)

### DIFF
--- a/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
+++ b/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
@@ -6,39 +6,39 @@ using NUnit.Framework;
 namespace Allure.NUnit.Examples
 {
     [AllureSuite("Tests - Async OneTime SetUp")]
-	[Parallelizable(ParallelScope.All)]
-	public class AllureAsyncOneTimeSetUpTests: BaseTest
-	{
-		[OneTimeSetUp]
-		[AllureBefore]
-		public async Task OneTimeSetUp()
-		{
+    [Parallelizable(ParallelScope.All)]
+    public class AllureAsyncOneTimeSetUpTests: BaseTest
+    {
+        [OneTimeSetUp]
+        [AllureBefore]
+        public async Task OneTimeSetUp()
+        {
             await AsyncStepsExamples.PrepareDough();
-			await AsyncStepsExamples.CookPizza();
-			await AsyncStepsExamples.CookPizza();
-			await AsyncStepsExamples.CookPizza();
-		}
+            await AsyncStepsExamples.CookPizza();
+            await AsyncStepsExamples.CookPizza();
+            await AsyncStepsExamples.CookPizza();
+        }
 
         [SetUp]
         [AllureBefore]
-		public async Task SetUp()
-		{
+        public async Task SetUp()
+        {
             await AsyncStepsExamples.PrepareDough();
-		}
+        }
 
         [Test]
-		[AllureName("Test1")]
-		public async Task Test1()
-		{
+        [AllureName("Test1")]
+        public async Task Test1()
+        {
             await AsyncStepsExamples.DeliverPizza();
-			await AsyncStepsExamples.Pay();
-		}
-		
-		[Test]
-		[AllureName("Test2")]
-		public async Task Test2()
-		{
+            await AsyncStepsExamples.Pay();
+        }
+        
+        [Test]
+        [AllureName("Test2")]
+        public async Task Test2()
+        {
             await AsyncStepsExamples.DeliverPizza();
-		}
-	}
+        }
+    }
 }

--- a/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
+++ b/Allure.NUnit.Examples/AllureAsyncOneTimeSetUpTests.cs
@@ -5,30 +5,32 @@ using NUnit.Framework;
 
 namespace Allure.NUnit.Examples
 {
-	[AllureSuite("Tests - Async OneTime SetUp")]
+    [AllureSuite("Tests - Async OneTime SetUp")]
 	[Parallelizable(ParallelScope.All)]
 	public class AllureAsyncOneTimeSetUpTests: BaseTest
 	{
 		[OneTimeSetUp]
+		[AllureBefore]
 		public async Task OneTimeSetUp()
 		{
-			await AsyncStepsExamples.PrepareDough();
+            await AsyncStepsExamples.PrepareDough();
 			await AsyncStepsExamples.CookPizza();
 			await AsyncStepsExamples.CookPizza();
 			await AsyncStepsExamples.CookPizza();
 		}
 
-		[SetUp]
+        [SetUp]
+        [AllureBefore]
 		public async Task SetUp()
 		{
-			await AsyncStepsExamples.PrepareDough();
+            await AsyncStepsExamples.PrepareDough();
 		}
 
-		[Test]
+        [Test]
 		[AllureName("Test1")]
 		public async Task Test1()
 		{
-			await AsyncStepsExamples.DeliverPizza();
+            await AsyncStepsExamples.DeliverPizza();
 			await AsyncStepsExamples.Pay();
 		}
 		
@@ -36,7 +38,7 @@ namespace Allure.NUnit.Examples
 		[AllureName("Test2")]
 		public async Task Test2()
 		{
-			await AsyncStepsExamples.DeliverPizza();
+            await AsyncStepsExamples.DeliverPizza();
 		}
 	}
 }

--- a/Allure.NUnit.Examples/AllureSetUpTearDownTest.cs
+++ b/Allure.NUnit.Examples/AllureSetUpTearDownTest.cs
@@ -36,12 +36,14 @@ namespace Allure.NUnit.Examples
         }
 
         [OneTimeSetUp]
+        [AllureBefore("OneTimeSetUp AllureBefore attribute description")]
         public void OneTimeSetUp()
         {
             Console.WriteLine("I'm an unwrapped OneTimeSetUp");
         }
 
         [OneTimeTearDown]
+        [AllureAfter("OneTimeTearDown AllureAfter attribute description")]
         public void OneTimeTearDown()
         {
             Console.WriteLine("I'm an unwrapped OneTimeTearDown");

--- a/Allure.NUnit/Attributes/AllureAfterAttribute.cs
+++ b/Allure.NUnit/Attributes/AllureAfterAttribute.cs
@@ -1,8 +1,10 @@
 using Allure.Net.Commons.Steps;
+using AspectInjector.Broker;
 using NUnit.Allure.Core;
 
 namespace NUnit.Allure.Attributes
 {
+    [Injection(typeof(Internals.StopContainerAspect), Inherited = true)]
     public class AllureAfterAttribute : AllureStepAttributes.AbstractAfterAttribute
     {
         public AllureAfterAttribute(string name = null) : base(name, AllureNUnitHelper.ExceptionTypes)

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -57,20 +57,32 @@ namespace NUnit.Allure.Core
                     Label.Thread(),
                     Label.Host(),
                     Label.Package(
-                        _test.ClassName?.Substring(
-                            0,
-                            _test.ClassName.LastIndexOf('.')
-                        )
+                        GetNamespace(_test.ClassName)
                     ),
                     Label.TestMethod(_test.MethodName),
                     Label.TestClass(
-                        _test.ClassName?.Substring(
-                            _test.ClassName.LastIndexOf('.') + 1
-                        )
+                        GetClassName(_test.ClassName)
                     )
                 }
             };
             AllureLifecycle.StartTestCase(testResult);
+        }
+
+        static string GetNamespace(string classFullName)
+        {
+            var lastDotIndex = classFullName?.LastIndexOf('.') ?? -1;
+            return lastDotIndex == -1 ? null : classFullName.Substring(
+                0,
+                lastDotIndex
+            );
+        }
+
+        static string GetClassName(string classFullName)
+        {
+            var lastDotIndex = classFullName?.LastIndexOf('.') ?? -1;
+            return lastDotIndex == -1 ? classFullName : classFullName.Substring(
+                lastDotIndex + 1
+            );
         }
 
         private TestFixture GetTestFixture(ITest test)

--- a/Allure.NUnit/Internals/StopContainerAspect.cs
+++ b/Allure.NUnit/Internals/StopContainerAspect.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Allure.Net.Commons;
+using AspectInjector.Broker;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace NUnit.Allure.Internals
+{
+    [Aspect(Scope.Global)]
+    public class StopContainerAspect
+    {
+        [Advice(Kind.Around)]
+        public object StopTestContainerAfterTheLastOneTimeTearDown(
+            [Argument(Source.Target)] Func<object[], object> target,
+            [Argument(Source.Metadata)] MethodBase metadata
+        )
+        {
+            if (IsOneTimeTearDown(metadata))
+            {
+                CurrentTearDownCount++;
+                if (IsLastTearDown)
+                {
+                    return CallAndStopContainer(target);
+                }
+            }
+            return target(Array.Empty<object>());
+        }
+
+        static object CallAndStopContainer(Func<object[], object> target)
+        {
+            object returnValue = null;
+            try
+            {
+                returnValue = target(Array.Empty<object>());
+            }
+            finally
+            {
+                if (returnValue is null)
+                {
+                    StopContainer();
+                }
+                else
+                {
+                    // This branch is executed only in case of an async one time tear down
+                    returnValue = StopContainerAfterAsyncTearDown(returnValue);
+                }
+            }
+            return returnValue;
+        }
+
+        async static Task StopContainerAfterAsyncTearDown(object awaitable)
+        {
+            await ((Task)awaitable).ConfigureAwait(false);
+            StopContainer();
+        }
+
+        static void StopContainer()
+        {
+            AllureLifecycle.Instance.StopTestContainer();
+            AllureLifecycle.Instance.WriteTestContainer();
+        }
+
+        static bool IsOneTimeTearDown(MethodBase metadata) =>
+            Attribute.IsDefined(
+                metadata,
+                typeof(OneTimeTearDownAttribute)
+            );
+
+        static bool IsLastTearDown
+        {
+            get => CurrentTearDownCount == TotalTearDownCount;
+        }
+
+        static int CurrentTearDownCount
+        {
+            get => (int?) TestExecutionContext.CurrentContext
+                .CurrentTest.Properties.Get(CurrentTearDownKey) ?? 0;
+            set => TestExecutionContext.CurrentContext
+                .CurrentTest.Properties.Set(
+                    CurrentTearDownKey,
+                    value
+                );
+        }
+
+        static int TotalTearDownCount
+        {
+            get => (
+                (TestSuite)TestExecutionContext.CurrentContext.CurrentTest
+            ).OneTimeTearDownMethods.Length;
+        }
+
+        const string CurrentTearDownKey = "CurrentTearDownCount";
+    }
+}

--- a/Allure.Net.Commons/AllureLifecycle.cs
+++ b/Allure.Net.Commons/AllureLifecycle.cs
@@ -136,6 +136,25 @@ public class AllureLifecycle
         }
     }
 
+    /// <summary>
+    /// Binds the provided value as the current Allure context. This allows the
+    /// Allure context to bypass .NET execution context boundaries. Use this
+    /// function in a highly concurrent environments where framework hooks and
+    /// user's test functions might all be run in different execution contexts.
+    /// For other scenarios consider using <see cref="RunInContext"/> first.
+    /// </summary>
+    /// <param name="context">
+    /// A context that was previously captured with <see cref="Context"/>.
+    /// It can't be null.
+    /// </param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public void RestoreContext(AllureContext context)
+    {
+        this.Context = context ?? throw new ArgumentNullException(
+            nameof(context)
+        );
+    }
+
     #region TestContainer
 
     /// <summary>


### PR DESCRIPTION
Currently there is a bug related to how Allure.NUnit reports OneTimeSetUp/OneTimeTearDown functions (see #374) and also some inconsistent behavior on top of that. In this work we aim to address the inconsistencies to make those fixtures usable and reportable.

## Context
The published version of Allure.NUnit (2.9.5-preview.1, as of the time of writing) includes the fixtures in the report but doesn't support steps inside of them (see #286).

The most recent (yet to publish) version (the one residing in the `preview` branch) allows steps in OneTimeSetUp, but has its own issues:

1. It squashes multiple OneTimeSetUp methods under a single fixture in the report (also duplicating it).
2. It creates OneTimeSetUp fixture even if it's not defined in the code (#374)
3. It ignores OneTimeTearDown. An attempt to add a step from such a method results in an exception because no allure context suitable for this operation exists at the moment.

## Changes
This PR removes special handling of OneTimeSetUp and OneTimeTearDown methods. Now you add those fixtures to the report in the same way you add SetUp and Tear down, i.e., via the `AllureBefore` or `AllureAfter` attributes. These attributes are required if you use steps inside the fixtures. This requirement might be lifted once we implement #370.

### Allure context changes
A special change was required to support OneTimeTearDown fixtures. To better illustrate it lets consider the following code:

```csharp
using NUnit.Allure.Attributes;
using NUnit.Allure.Core;
using NUnit.Framework;

namespace MyNamespace
{
    [AllureNUnit]
    class MyTestClass
    {
        [OneTimeSetUp]
        [AllureBefore]
        public void OneTimeSetUp() { }

        [SetUp]
        [AllureBefore]
        public void SetUp() { }

        [OneTimeTearDown]
        [AllureAfter]
        public void OneTimeTearDown() { }

        [TearDown]
        [AllureAfter]
        public void TearDown() { }

        [Test]
        public void Test1() { }

        [Test]
        public void Test2() { }
    }
}
```

When NUnit runs such a test class it might spread the hooks from [NUnit.Allure.Core.AllureNUnitAttribute][AllureNUnitAttribute] as well as the code of the tests across different threads in a manner similar to this:

| Test | Function | Type | Thread |
|--------|--------|--------|--------|
| - | ApplyToContext | Class-level hook | 1 |
| - | OneTimeSetUp | Class-level fixture | 1 |
| - | BeforeTest | Class-level hook | 1 |
| Test1 | BeforeTest | Test-level hook | 2 |
| Test1 | SetUp | Test-level fixture | 2 |
| Test1 | Test1 | Test method | 2 |
| Test1 | TearDown | Test-level fixture | 2 |
| Test1 | AfterTest | Test-level hook | 2 |
| Test2 | BeforeTest | Test-level hook | 3 |
| Test2 | SetUp | Test-level fixture | 3 |
| Test2 | Test2 | Test method | 3 |
| Test2 | TearDown | Test-level fixture | 3 |
| Test2 | AfterTest | Test-level hook | 3 |
| - | AfterTest | Class-level hook | 4 |
| - | OneTimeTearDown | Class-level fixture | 4 |

This distribution across unrelated threads (most likely, in a thread pool) makes a container created in `ApplyToContext` to hold class-level fixtures not accessible in `AfterTest` and `OneTimeTearDown` leading to an invalid allure context exception.

To fix this it's required to capture the context in the thread 1, restore it during `BeforeTest` in the thread 2 and 3, modify it again and make sure the modified context remains accessible for the subsequent functions in the same threads. We can't achieve this using the current API for restoring a captured context: `AllureLifecycle.RunInContext`.

#### New AllureContext API

A new API was added for such scenarios: `AllureLifecycle.RestoreContext`. The hooks in AllureNunitAttribute class now use this method as part of the `Restore -> Modify -> Capture` sequence to ensure that the valid context is available for all hooks, fixtures and tests.

### Additional fixes
This also fixes a minor issue with empty namespaces by adding checks on the return values of `LastIndexOf` (see #375).


### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

Fixes #286 
Partially fixes #325 
Fixes #374 
Fixes #375 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
[AllureNUnitAttribute]: https://github.com/allure-framework/allure-csharp/blob/18679f7a6036677743b19b52f5589260117040e3/Allure.NUnit/Core/AllureNUnitAttribute.cs