### PR TITLE
Allure-xunit: support for the second reporter and xunit 2.5.0. Updated packaging and AspectInjector (fixes 368)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,10 +28,10 @@ jobs:
         run: dotnet restore ${{ env.SOLUTION_PATH }} --packages ${{ env.RESTORE_OUTPUT_PATH }}
 
       - name: 'Build project using dotnet'
-        run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }}
+        run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }} -p:ContinuousIntegrationBuild=true
 
       - name: 'Pack project'
-        run: dotnet pack ${{ env.SOLUTION_PATH }} --no-restore --no-build --configuration ${{ env.BUILD_CONFIGURATION }} --include-symbols --include-source -p:PackageOutputPath=${{ env.PACKAGE_OUTPUT_PATH }}
+        run: dotnet pack ${{ env.SOLUTION_PATH }} --no-restore --no-build --configuration ${{ env.BUILD_CONFIGURATION }} -p:PackageOutputPath=${{ env.PACKAGE_OUTPUT_PATH }}
 
       - name: 'NuGet publish'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,8 @@ jobs:
           git config --global user.email qameta-ci@qameta.io
       - name: "Set release version"
         run: |
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ env.release_version }}</Version>|g' ./Allure.Net.Commons/Allure.Net.Commons.csproj
-          cat ./Allure.Net.Commons/Allure.Net.Commons.csproj
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ env.release_version }}</Version>|g' ./Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
-          cat ./Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ env.release_version }}</Version>|g' ./Allure.XUnit/Allure.XUnit.csproj
-          cat ./Allure.XUnit/Allure.XUnit.csproj
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ env.release_version }}</Version>|g' ./Allure.NUnit/Allure.NUnit.csproj
-          cat ./Allure.NUnit/Allure.NUnit.csproj
+          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ env.release_version }}</Version>|g' ./Directory.Build.props
+          cat ./Directory.Build.props
       - name: "Commit release version and create tag"
         run: |
           git commit -am "release ${{ env.release_version }}"
@@ -60,14 +54,8 @@ jobs:
           git push origin ${{ env.release_version }}
       - name: "Set next development version"
         run: |
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ inputs.nextVersion }}-SNAPSHOT</Version>|g' ./Allure.Net.Commons/Allure.Net.Commons.csproj
-          cat ./Allure.Net.Commons/Allure.Net.Commons.csproj
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ inputs.nextVersion }}-SNAPSHOT</Version>|g' ./Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
-          cat ./Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ inputs.nextVersion }}-SNAPSHOT</Version>|g' ./Allure.XUnit/Allure.XUnit.csproj
-          cat ./Allure.XUnit/Allure.XUnit.csproj
-          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ inputs.nextVersion }}-SNAPSHOT</Version>|g' ./Allure.NUnit/Allure.NUnit.csproj
-          cat ./Allure.NUnit/Allure.NUnit.csproj
+          sed -i -e '/<PropertyGroup>/,/<\/PropertyGroup>/ s|<Version>[0-9a-zA-Z.|-]*</Version>|<Version>${{ inputs.nextVersion }}-SNAPSHOT</Version>|g' ./Directory.Build.props
+          cat ./Directory.Build.props
       - name: "Commit next development version and push it"
         run: |
           git commit -am "set next development version ${{ inputs.nextVersion }}"

--- a/Allure.Features/Allure.Features.csproj
+++ b/Allure.Features/Allure.Features.csproj
@@ -1,33 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-	<LangVersion>11</LangVersion>
-    <IsPackable>false</IsPackable>
-    <OutputPath>bin</OutputPath>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <OutputPath>bin</OutputPath>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Castle.Core" Version="4.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.9.74" />
-    <PackageReference Include="SpecFlow.SharedSteps" Version="3.0.7" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.9.8" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Allure.Net.Commons\Allure.Net.Commons.csproj" />
-    <ProjectReference Include="..\Allure.SpecFlowPlugin\Allure.SpecFlowPlugin.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="allureConfig.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="specflow.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Castle.Core" Version="4.4.1" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="SpecFlow" Version="3.9.74" />
+        <PackageReference Include="SpecFlow.SharedSteps" Version="3.0.7" />
+        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
+        <PackageReference Include="SpecFlow.NUnit" Version="3.9.8" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Allure.Net.Commons\Allure.Net.Commons.csproj" />
+        <ProjectReference Include="..\Allure.SpecFlowPlugin\Allure.SpecFlowPlugin.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="allureConfig.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="specflow.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 </Project>

--- a/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
+++ b/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
@@ -1,30 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-	<LangVersion>11</LangVersion>
-    <IsPackable>false</IsPackable>
-    <OutputType>Library</OutputType>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <OutputType>Library</OutputType>
+        <AspectInjector_Enabled>true</AspectInjector_Enabled>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Allure.NUnit\Allure.NUnit.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Allure.NUnit\Allure.NUnit.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <Resource Include="allureConfig.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Resource>
-    <Resource Include="AllureIgnoredTest.cs" />
-    <None Include="./../img/Allure-Color.png" PackagePath="\">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <Resource Include="allureConfig.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Resource>
+        <Resource Include="AllureIgnoredTest.cs" />
+        <None Include="./../img/Allure-Color.png" PackagePath="\">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
+++ b/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <OutputType>Library</OutputType>
-        <AspectInjector_Enabled>true</AspectInjector_Enabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Allure.NUnit/Allure.NUnit.csproj
+++ b/Allure.NUnit/Allure.NUnit.csproj
@@ -2,33 +2,20 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>11</LangVersion>
-        <Version>2.10-SNAPSHOT</Version>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <Company>Qameta Software</Company>
+        <IsPackable>true</IsPackable>
         <Authors>Nick Chursin</Authors>
         <Description>NUnit attributes extenstions for Allure</Description>
         <PackageId>Allure.NUnit</PackageId>
         <AssemblyName>Allure.NUnit</AssemblyName>
         <RootNamespace>NUnit.Allure</RootNamespace>
         <PackageProjectUrl>https://www.nuget.org/packages/Allure.NUnit</PackageProjectUrl>
-        <RepositoryUrl>https://github.com/allure-framework/allure-csharp</RepositoryUrl>
         <PackageTags>allure nunit</PackageTags>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>Allure-N-Color.png</PackageIcon>
-        <IncludeSymbols>true</IncludeSymbols>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="AspectInjector" Version="2.8.1" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit.Engine.Api" Version="3.15.2" />
     </ItemGroup>

--- a/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
+++ b/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
@@ -1,33 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <LangVersion>11</LangVersion>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Castle.Core" Version="5.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Moq" Version="4.18.1" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Allure.Net.Commons\Allure.Net.Commons.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Allure.Net.Commons\Allure.Net.Commons.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="actual.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="diff.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="expected.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="actual.png">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="diff.png">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="expected.png">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/Allure.Net.Commons/Allure.Net.Commons.csproj
+++ b/Allure.Net.Commons/Allure.Net.Commons.csproj
@@ -5,7 +5,7 @@
         <IsPackable>true</IsPackable>
         <Authors>Alexander Bakanov, Nikolay Laptev</Authors>
         <Product />
-        <Description>.NET implementation of Allure java-commons</Description>
+        <Description>Provides common facilities to build allure integrations for .NET test frameworks</Description>
         <PackageProjectUrl>https://www.nuget.org/packages/Allure.Net.Commons</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>allure</PackageTags>

--- a/Allure.Net.Commons/Allure.Net.Commons.csproj
+++ b/Allure.Net.Commons/Allure.Net.Commons.csproj
@@ -2,40 +2,22 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-		<LangVersion>11</LangVersion>
-        <Version>2.10-SNAPSHOT</Version>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <IsPackable>true</IsPackable>
         <Authors>Alexander Bakanov, Nikolay Laptev</Authors>
-        <Company>Qameta Software</Company>
         <Product />
         <Description>.NET implementation of Allure java-commons</Description>
         <PackageProjectUrl>https://www.nuget.org/packages/Allure.Net.Commons</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <RepositoryUrl>https://github.com/allure-framework/allure-csharp</RepositoryUrl>
-        <RepositoryType>git</RepositoryType>
         <PackageTags>allure</PackageTags>
         <PackageIcon>Allure-Color.png</PackageIcon>
-        <SignAssembly>False</SignAssembly>
-        <DelaySign>False</DelaySign>
-        <AssemblyOriginatorKeyFile>key.snk</AssemblyOriginatorKeyFile>
-        <LangVersion>default</LangVersion>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <AspectInjector_Enabled>true</AspectInjector_Enabled>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    </ItemGroup>
-    
-    <ItemGroup>
-        <PackageReference Include="AspectInjector" Version="2.8.1" />
-    </ItemGroup>
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\" />
         <None Include="./../img/Allure-Color.png" Pack="true" PackagePath="\" />
         <Content Include="allureConfig.Template.json" Pack="true" />
+        <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="MimeTypesMap" Version="1.0.8" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />

--- a/Allure.Net.Commons/Allure.Net.Commons.csproj
+++ b/Allure.Net.Commons/Allure.Net.Commons.csproj
@@ -10,7 +10,6 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>allure</PackageTags>
         <PackageIcon>Allure-Color.png</PackageIcon>
-        <AspectInjector_Enabled>true</AspectInjector_Enabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Allure.Net.Commons/AllureLifecycle.cs
+++ b/Allure.Net.Commons/AllureLifecycle.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Allure.Net.Commons.Configuration;
 using Allure.Net.Commons.Storage;
@@ -13,8 +12,6 @@ using HeyRed.Mime;
 using Newtonsoft.Json.Linq;
 
 #nullable enable
-
-[assembly: InternalsVisibleTo("Allure.Net.Commons.Tests")]
 
 namespace Allure.Net.Commons;
 

--- a/Allure.Net.Commons/Internal/AssemblyAttributes.cs
+++ b/Allure.Net.Commons/Internal/AssemblyAttributes.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Allure.Net.Commons.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Allure.Net.Commons/Writer/FileSystemResultsWriter.cs
+++ b/Allure.Net.Commons/Writer/FileSystemResultsWriter.cs
@@ -1,14 +1,10 @@
 ﻿using System;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using Allure.Net.Commons.Configuration;
 using Allure.Net.Commons.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-
-[assembly: InternalsVisibleTo("Allure.Net.Commons.Tests")]
-[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 namespace Allure.Net.Commons.Writer
 {

--- a/Allure.SpecFlowPlugin.Tests/Allure.SpecFlowPlugin.Tests.csproj
+++ b/Allure.SpecFlowPlugin.Tests/Allure.SpecFlowPlugin.Tests.csproj
@@ -1,31 +1,29 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-	<LangVersion>11</LangVersion>
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
   
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\Allure.SpecFlowPlugin\Allure.SpecFlowPlugin.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Allure.SpecFlowPlugin\Allure.SpecFlowPlugin.csproj" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="allureConfigStepArguments.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="allureConfig.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="allureConfigWithInvalidRegex.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="allureConfigStepArguments.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="allureConfig.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="allureConfigWithInvalidRegex.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
+++ b/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
@@ -2,36 +2,25 @@
 
     <PropertyGroup>
         <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
-        <LangVersion>11</LangVersion>
+        <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <PackageId>Allure.SpecFlow</PackageId>
-        <Version>2.10-SNAPSHOT</Version>
         <Authors>Alexander Bakanov</Authors>
-        <Company>Qameta Software</Company>
         <Product />
         <Description>Generates Allure report result files for SpecFlow test run</Description>
         <PackageProjectUrl>https://www.nuget.org/packages/Allure.SpecFlow</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>Allure-SF-Color.png</PackageIcon>
-        <RepositoryUrl>https://github.com/allure-framework/allure-csharp</RepositoryUrl>
         <PackageTags>specflow allure</PackageTags>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    </ItemGroup>
 
     <ItemGroup>
         <None Include="README.md" Pack="true" PackagePath="\" />
         <Content Include="allureConfig.Template.json" Pack="true" />
         <None Include="./../img/Allure-SF-Color.png" Pack="true" PackagePath="\" />
         <None Update="LICENSE.md">
-          <Pack>true</Pack>
-          <PackagePath>/</PackagePath>
+            <Pack>true</Pack>
+            <PackagePath>/</PackagePath>
         </None>
     </ItemGroup>
 

--- a/Allure.XUnit.Examples/Allure.XUnit.Examples.csproj
+++ b/Allure.XUnit.Examples/Allure.XUnit.Examples.csproj
@@ -1,32 +1,32 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <IsPackable>false</IsPackable>
         <TargetFramework>net6.0</TargetFramework>
-		<LangVersion>11</LangVersion>
+        <AspectInjector_Enabled>true</AspectInjector_Enabled>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="coverlet.collector" Version="3.2.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-      <Content Include="allureConfig.json">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </Content>
+        <Content Include="allureConfig.json">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </Content>
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Allure.XUnit\Allure.XUnit.csproj" />
+        <ProjectReference Include="..\Allure.XUnit.Reporters\Allure.XUnit.Reporters.csproj" />
+        <ProjectReference Include="..\Allure.XUnit\Allure.XUnit.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Allure.XUnit.Examples/Allure.XUnit.Examples.csproj
+++ b/Allure.XUnit.Examples/Allure.XUnit.Examples.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <AspectInjector_Enabled>true</AspectInjector_Enabled>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Allure.XUnit.Examples/allureConfig.json
+++ b/Allure.XUnit.Examples/allureConfig.json
@@ -4,6 +4,7 @@
     "links": [
       "https://example.org/{issue}",
       "https://example.org/{tms}"
-    ]
+    ],
+    "xunitReporter": "auto"
   }
 }

--- a/Allure.XUnit.Examples/allureConfig.json
+++ b/Allure.XUnit.Examples/allureConfig.json
@@ -5,6 +5,6 @@
       "https://example.org/{issue}",
       "https://example.org/{tms}"
     ],
-    "xunitReporter": "auto"
+    "xunitRunnerReporter": "auto"
   }
 }

--- a/Allure.XUnit.Reporters/Allure.XUnit.Reporters.csproj
+++ b/Allure.XUnit.Reporters/Allure.XUnit.Reporters.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetName>Allure.XUnit.reporters</TargetName>
+        <TargetFrameworks>netcoreapp2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
+        <ProjectReference Include="..\Allure.XUnit\Allure.XUnit.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Allure.XUnit.Reporters/AllureRunnerReporter.cs
+++ b/Allure.XUnit.Reporters/AllureRunnerReporter.cs
@@ -1,0 +1,20 @@
+﻿using Xunit;
+using Xunit.Abstractions;
+
+#nullable enable
+
+namespace Allure.XUnit.Reporters
+{
+    public class AllureRunnerReporter : IRunnerReporter
+    {
+        public string Description { get; }
+            = "Creates allure input files for xunit tests";
+
+        public bool IsEnvironmentallyEnabled { get; } = true;
+
+        public string RunnerSwitch { get; } = "allure";
+
+        public IMessageSink CreateMessageHandler(IRunnerLogger logger) =>
+            AllureXunitFacade.CreateAllureXunitMessageHandler(logger);
+    }
+}

--- a/Allure.XUnit/Allure.XUnit.csproj
+++ b/Allure.XUnit/Allure.XUnit.csproj
@@ -2,29 +2,25 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
-        <LangVersion>11</LangVersion>
         <IsPackable>true</IsPackable>
-        <Company>Qameta Software</Company>
-        <Version>2.10-SNAPSHOT</Version>
         <Title>Allure.XUnit</Title>
         <Authors>Shumakov Ivan</Authors>
         <Description>Allure.XUnit</Description>
         <PackageIcon>Allure-X-Color.png</PackageIcon>
         <PackageProjectUrl>https://www.nuget.org/packages/Allure.XUnit</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
-        <RepositoryUrl>https://github.com/allure-framework/allure-csharp</RepositoryUrl>
         <PackageTags>allure xunit</PackageTags>
-        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-        <IncludeSymbols>true</IncludeSymbols>
-        <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <AspectInjector_Enabled>true</AspectInjector_Enabled>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);PackAllureXunitReportersFiles</TargetsForTfmSpecificBuildOutput>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspectInjector" Version="2.8.2" />
         <PackageReference Include="Lib.Harmony" Version="2.3.0-prerelease.2" />
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-        <PackageReference Include="xunit.runner.utility" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
     </ItemGroup>
 
     <ItemGroup>
@@ -37,10 +33,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspectInjector" Version="2.8.1" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />
         <PackageReference Include="xunit.core" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.reporters" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.reporters" Version="2.4.1" />
     </ItemGroup>
 
     <ItemGroup>
@@ -49,5 +44,12 @@
             <!-- <PrivateAssets>all</PrivateAssets>-->
         </ProjectReference>
     </ItemGroup>
+
+    <Target Name="PackAllureXunitReportersFiles">
+        <ItemGroup>
+            <BuildOutputInPackage Include="./../Allure.XUnit.Reporters/bin/$(Configuration)/$(TargetFramework)/Allure.XUnit.reporters.dll" />
+            <BuildOutputInPackage Include="./../Allure.XUnit.Reporters/bin/$(Configuration)/$(TargetFramework)/Allure.XUnit.reporters.pdb" />
+        </ItemGroup>
+    </Target>
 
 </Project>

--- a/Allure.XUnit/Allure.XUnit.csproj
+++ b/Allure.XUnit/Allure.XUnit.csproj
@@ -10,7 +10,6 @@
         <PackageProjectUrl>https://www.nuget.org/packages/Allure.XUnit</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>allure xunit</PackageTags>
-        <AspectInjector_Enabled>true</AspectInjector_Enabled>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/Allure.XUnit/AllureMessageSink.cs
+++ b/Allure.XUnit/AllureMessageSink.cs
@@ -29,6 +29,8 @@ namespace Allure.XUnit
             this.Execution.TestPassedEvent += this.OnTestPassed;
             this.Execution.TestSkippedEvent += this.OnTestSkipped;
             this.Execution.TestFinishedEvent += this.OnTestFinished;
+
+            CurrentSink ??= this;
         }
 
         void OnTestAssemblyExecutionStarting(
@@ -173,5 +175,7 @@ namespace Allure.XUnit
 
         static bool IsStaticTestMethod(ITestMethodMessage message) =>
             message.TestMethod.Method.IsStatic;
+
+        public static AllureMessageSink? CurrentSink { get; private set; }
     }
 }

--- a/Allure.XUnit/AllureMessageSink.cs
+++ b/Allure.XUnit/AllureMessageSink.cs
@@ -11,16 +11,14 @@ using Xunit.Abstractions;
 
 namespace Allure.XUnit
 {
-    public class AllureMessageSink : TestMessageSink
+    public class AllureMessageSink :
+        DefaultRunnerReporterWithTypesMessageHandler
     {
-        readonly IRunnerLogger logger;
-        readonly ConcurrentDictionary<ITest, AllureXunitTestData> allureTestData
-            = new();
+        readonly ConcurrentDictionary<ITest, AllureXunitTestData>
+            allureTestData = new();
 
-        public AllureMessageSink(IRunnerLogger logger)
+        public AllureMessageSink(IRunnerLogger logger) : base(logger)
         {
-            this.logger = logger;
-
             this.Runner.TestAssemblyExecutionStartingEvent +=
                 this.OnTestAssemblyExecutionStarting;
 
@@ -31,34 +29,6 @@ namespace Allure.XUnit
             this.Execution.TestPassedEvent += this.OnTestPassed;
             this.Execution.TestSkippedEvent += this.OnTestSkipped;
             this.Execution.TestFinishedEvent += this.OnTestFinished;
-        }
-
-        public override bool OnMessageWithTypes(
-            IMessageSinkMessage message,
-            HashSet<string> messageTypes
-        )
-        {
-            try
-            {
-                this.logger.LogMessage(message.GetType().Name);
-                return base.OnMessageWithTypes(message, messageTypes);
-            }
-            catch (Exception e)
-            {
-                if (message is ITestCaseMessage testCaseMessage)
-                {
-                    this.logger.LogError(
-                        "Error during execution of {0}: {1}",
-                        testCaseMessage.TestCase.DisplayName,
-                        e
-                    );
-                }
-                else
-                {
-                    this.logger.LogError(e.ToString());
-                }
-                return false;
-            }
         }
 
         void OnTestAssemblyExecutionStarting(
@@ -198,7 +168,7 @@ namespace Allure.XUnit
             message += ". You may try to compile the project in debug mode " +
                 "as a workaround";
 #endif
-            this.logger.LogWarning(message);
+            this.Logger.LogWarning(message);
         }
 
         static bool IsStaticTestMethod(ITestMethodMessage message) =>

--- a/Allure.XUnit/AllureRunnerReporter.cs
+++ b/Allure.XUnit/AllureRunnerReporter.cs
@@ -1,5 +1,11 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 using Xunit.Abstractions;
+
+#nullable enable
 
 namespace Allure.XUnit
 {
@@ -16,9 +22,88 @@ namespace Allure.XUnit
             AllureXunitPatcher.PatchXunit(logger);
             var sink = new AllureMessageSink(logger);
             CurrentSink ??= sink;
-            return sink;
+            return TryWrapSecondReporter(logger, sink);
         }
 
-        internal static AllureMessageSink CurrentSink { get; private set; }
+        internal static AllureMessageSink? CurrentSink { get; private set; }
+
+        static IMessageSink TryWrapSecondReporter(
+            IRunnerLogger logger,
+            AllureMessageSink allureSink
+        ) =>
+            TryWrapResolvedReporter(
+                logger,
+                allureSink,
+                ResolveReporter()
+            );
+
+        static IMessageSink TryWrapResolvedReporter(
+            IRunnerLogger logger,
+            AllureMessageSink allureSink,
+            IRunnerReporter? secondReporter
+        ) =>
+            secondReporter is null ? allureSink : new ComposedMessageSink(
+                allureSink,
+                secondReporter.CreateMessageHandler(logger)
+            );
+
+        static IRunnerReporter? ResolveReporter() =>
+            AllureXunitConfiguration.CurrentConfig.XunitReporter switch
+            {
+                "none" => null,
+                "auto" => ResolveAutoReporter(),
+                string reporterName => ResolveExplicitReporter(reporterName)
+            };
+
+        static IRunnerReporter? ResolveAutoReporter() =>
+            (
+                from reporter in GetReporters()
+                where reporter.IsEnvironmentallyEnabled
+                select reporter
+            ).FirstOrDefault();
+
+        static IRunnerReporter ResolveExplicitReporter(string reporterName) =>
+            TryCreateReporterByType(
+                Type.GetType(reporterName)
+            ) ?? TryCreateReporterByName(reporterName)
+                ?? throw new InvalidOperationException(
+                    $"Can't load the {reporterName} reporter"
+                );
+
+        static IRunnerReporter? TryCreateReporterByType(Type? reporterType) =>
+            reporterType is null
+                ? null
+                : ((IRunnerReporter)Activator.CreateInstance(reporterType));
+
+        static IRunnerReporter? TryCreateReporterByName(string reporterName) =>
+            (
+                from reporter in GetReporters()
+                where StringComparer.OrdinalIgnoreCase.Equals(
+                    reporter.RunnerSwitch,
+                    reporterName
+                )
+                select reporter
+            ).FirstOrDefault();
+
+        static IEnumerable<IRunnerReporter> GetReporters() =>
+            from assembly in AppDomain.CurrentDomain.GetAssemblies()
+            where IsPotentialReporterAssembly(assembly)
+            from type in assembly.GetTypes()
+            where IsReporterType(type)
+            select (IRunnerReporter)Activator.CreateInstance(type);
+
+        static bool IsPotentialReporterAssembly(Assembly assembly) =>
+            !assembly.FullName.StartsWith("System.")
+                &&
+            !assembly.FullName.StartsWith("Microsoft.");
+
+        static bool IsReporterType(Type type) =>
+            type.GetInterfaces().Contains(typeof(IRunnerReporter))
+                &&
+            !type.IsAbstract
+                &&
+            !type.IsGenericTypeDefinition
+                &&
+            type != typeof(AllureRunnerReporter);
     }
 }

--- a/Allure.XUnit/AllureXunitConfiguration.cs
+++ b/Allure.XUnit/AllureXunitConfiguration.cs
@@ -12,7 +12,7 @@ namespace Allure.XUnit
 {
     internal class AllureXunitConfiguration : AllureConfiguration
     {
-        public string XunitReporter { get; set; } = "auto";
+        public string XunitRunnerReporter { get; set; } = "auto";
 
         [JsonConstructor]
         protected AllureXunitConfiguration(

--- a/Allure.XUnit/AllureXunitConfiguration.cs
+++ b/Allure.XUnit/AllureXunitConfiguration.cs
@@ -1,0 +1,41 @@
+﻿using Allure.Net.Commons;
+using Allure.Net.Commons.Configuration;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+#nullable enable
+
+namespace Allure.XUnit
+{
+    internal class AllureXunitConfiguration : AllureConfiguration
+    {
+        public string XunitReporter { get; set; } = "auto";
+
+        [JsonConstructor]
+        protected AllureXunitConfiguration(
+            string title,
+            string directory,
+            HashSet<string> links
+        ) : base(title, directory, links)
+        {
+        }
+
+        public static AllureXunitConfiguration CurrentConfig
+        {
+            get => currentConfig.Value;
+        }
+
+        static readonly Lazy<AllureXunitConfiguration> currentConfig
+            = new(ParseCurrentConfig);
+
+        static AllureXunitConfiguration ParseCurrentConfig() => JObject.Parse(
+            AllureLifecycle.Instance.JsonConfiguration
+        )["allure"]?.ToObject<AllureXunitConfiguration>()
+            ?? throw new FileNotFoundException(
+                "allureConfig.json not found"
+            );
+    }
+}

--- a/Allure.XUnit/AllureXunitFacade.cs
+++ b/Allure.XUnit/AllureXunitFacade.cs
@@ -58,13 +58,19 @@ namespace Allure.XUnit
                 select reporter
             ).FirstOrDefault();
 
-        static IRunnerReporter ResolveExplicitReporter(string reporterName) =>
-            TryCreateReporterByType(
-                Type.GetType(reporterName)
-            ) ?? TryCreateReporterByName(reporterName)
-                ?? throw new InvalidOperationException(
+        static IRunnerReporter ResolveExplicitReporter(string reporterName)
+        {
+            var reporterType = Type.GetType(reporterName);
+            var resolvedReporter = TryCreateReporterByType(reporterType);
+            resolvedReporter ??= TryCreateReporterByName(reporterName);
+            if (resolvedReporter is null)
+            {
+                throw new InvalidOperationException(
                     $"Can't load the {reporterName} reporter"
                 );
+            }
+            return resolvedReporter;
+        }
 
         static IRunnerReporter? TryCreateReporterByType(Type? reporterType) =>
             reporterType is null

--- a/Allure.XUnit/AllureXunitPatcher.cs
+++ b/Allure.XUnit/AllureXunitPatcher.cs
@@ -77,7 +77,7 @@ namespace Allure.XUnit
             object[] testMethodArguments
         )
         {
-            if (AllureRunnerReporter.CurrentSink is null)
+            if (AllureMessageSink.CurrentSink is null)
             {
                 logger.LogWarning(
                     "Unable to get current message sink from the test " +
@@ -87,7 +87,7 @@ namespace Allure.XUnit
             }
             else
             {
-                AllureRunnerReporter.CurrentSink.OnTestArgumentsCreated(
+                AllureMessageSink.CurrentSink.OnTestArgumentsCreated(
                     test,
                     testMethodArguments
                 );

--- a/Allure.XUnit/ComposedMessageSink.cs
+++ b/Allure.XUnit/ComposedMessageSink.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Allure.XUnit
+{
+    internal class ComposedMessageSink : IMessageSink, IMessageSinkWithTypes
+    {
+        readonly IMessageSink[] sinks;
+
+        public ComposedMessageSink(params IMessageSink[] sinks)
+        {
+            this.sinks = sinks;
+        }
+
+        public void Dispose() { }
+
+        public bool OnMessage(IMessageSinkMessage message)
+        {
+            foreach (var sink in sinks)
+            {
+                if (!sink.OnMessage(message))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public bool OnMessageWithTypes(IMessageSinkMessage message, HashSet<string> messageTypes)
+        {
+            foreach(var sink in this.sinks)
+            {
+                if (!DispatchTypedSinkMessage(sink, message, messageTypes))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static bool DispatchTypedSinkMessage(
+            IMessageSink sink,
+            IMessageSinkMessage message,
+            HashSet<string> messageTypes
+        ) =>
+            sink is IMessageSinkWithTypes typedSink
+                ? typedSink.OnMessageWithTypes(message, messageTypes)
+                : sink.OnMessage(message);
+    }
+}

--- a/Allure.XUnit/README.md
+++ b/Allure.XUnit/README.md
@@ -194,8 +194,11 @@ Use [`AllureAttachments`](AllureAttachments.cs) class with its methods. (Attachm
 ## Known issues and limitations
 
 ### allureConfig.json is required even if no config properties are present
+
 The configuration file must be present in the output directory. Allure.XUnit
 throws otherwise. This requirement will be lifted in the near future.
+
+Here is the issue to track the progress: [#381].
 
 ### Arguments of some theories might be unreported
 
@@ -210,3 +213,4 @@ workaround until we come up with a solution.
 See [Examples](../Allure.XUnit.Examples).
 
 [#369]: https://github.com/allure-framework/allure-csharp/issues/369
+[#381]: https://github.com/allure-framework/allure-csharp/issues/381

--- a/Allure.XUnit/README.md
+++ b/Allure.XUnit/README.md
@@ -20,7 +20,7 @@ basic content of the config:
 
 Make sure the config is copied to the output directory:
 
-  - In Visual Studio select the file and the following properties:
+  - In Visual Studio select the file and set the following properties:
       - Build Action: Content
       - Copy to Output Directory: Always/Copy if newer
     OR

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,7 +16,7 @@
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
     </PropertyGroup>
 
-    <!-- AspectInjector is explicitly enabled for projects with aspects/injections -->
+    <!-- AspectInjector should be explicitly enabled for projects with aspects/injections -->
     <PropertyGroup>
         <AspectInjector_Enabled>false</AspectInjector_Enabled>
     </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,11 +16,6 @@
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
     </PropertyGroup>
 
-    <!-- AspectInjector should be explicitly enabled for projects with aspects/injections -->
-    <PropertyGroup>
-        <AspectInjector_Enabled>false</AspectInjector_Enabled>
-    </PropertyGroup>
-    
     <!-- Signing properties -->
     <PropertyGroup>
         <SignAssembly>false</SignAssembly>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,43 @@
+<Project>
+    <!-- Metadata -->
+    <PropertyGroup>
+        <Version>2.10-SNAPSHOT</Version>
+        <Company>Qameta Software</Company>
+        <RepositoryUrl>https://github.com/allure-framework/allure-csharp</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+    </PropertyGroup>
+
+    <!-- Common projects' properties -->
+    <PropertyGroup>
+        <LangVersion>11</LangVersion>
+        <IsPackable>false</IsPackable>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    </PropertyGroup>
+
+    <!-- AspectInjector is explicitly enabled for projects with aspects/injections -->
+    <PropertyGroup>
+        <AspectInjector_Enabled>false</AspectInjector_Enabled>
+    </PropertyGroup>
+    
+    <!-- Signing properties -->
+    <PropertyGroup>
+        <SignAssembly>false</SignAssembly>
+        <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)key.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
+
+    <!-- Debug properties -->
+    <PropertyGroup>
+        <DebugSymbols>true</DebugSymbols>
+        <DebugType>portable</DebugType>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    </PropertyGroup>
+
+    <!-- Enable SourceLink for all projects -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    </ItemGroup>
+</Project>

--- a/allure-csharp.sln
+++ b/allure-csharp.sln
@@ -1,13 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34024.191
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.Net.Commons", "Allure.Net.Commons\Allure.Net.Commons.csproj", "{C84000AF-0B78-4E87-B99B-064E15C601C7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.Net.Commons.Tests", "Allure.Net.Commons.Tests\Allure.Net.Commons.Tests.csproj", "{2E3DF5C2-8A38-4A03-86D7-8D463C917E47}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "commons", "commons", "{E0035B29-14C0-4270-B11F-DD2544D37FF6}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "specflow", "specflow", "{9AC8581F-7E9E-46B1-A30A-5A815966C820}"
 EndProject
@@ -15,19 +18,21 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.SpecFlowPlugin", "Al
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.SpecFlowPlugin.Tests", "Allure.SpecFlowPlugin.Tests\Allure.SpecFlowPlugin.Tests.csproj", "{69C462C3-E955-4B0C-9F1F-2ED5AE1BF270}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Allure.Features", "Allure.Features\Allure.Features.csproj", "{9F2B97FF-6798-4A69-9520-CE3491396F3F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.Features", "Allure.Features\Allure.Features.csproj", "{9F2B97FF-6798-4A69-9520-CE3491396F3F}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "allure-xunit", "allure-xunit", "{138A76FC-B163-423C-8FF8-D374F1C7EC2F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Allure.XUnit", "Allure.XUnit\Allure.XUnit.csproj", "{D278CE6B-F3D1-4FEF-BE5F-5AC6F6C53879}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.XUnit", "Allure.XUnit\Allure.XUnit.csproj", "{D278CE6B-F3D1-4FEF-BE5F-5AC6F6C53879}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Allure.XUnit.Examples", "Allure.XUnit.Examples\Allure.XUnit.Examples.csproj", "{38CF463E-F564-477D-A853-407F0648E0DD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.XUnit.Examples", "Allure.XUnit.Examples\Allure.XUnit.Examples.csproj", "{38CF463E-F564-477D-A853-407F0648E0DD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "allure-nunit", "allure-nunit", "{D0D75FDF-4884-4AC1-868F-B3F248CB74ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Allure.NUnit", "Allure.NUnit\Allure.NUnit.csproj", "{81F804C5-C437-4079-9731-97C6A2A86C48}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.NUnit", "Allure.NUnit\Allure.NUnit.csproj", "{81F804C5-C437-4079-9731-97C6A2A86C48}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Allure.NUnit.Examples", "Allure.NUnit.Examples\Allure.NUnit.Examples.csproj", "{77893A8D-4313-4211-AFF1-642E866A07C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.NUnit.Examples", "Allure.NUnit.Examples\Allure.NUnit.Examples.csproj", "{77893A8D-4313-4211-AFF1-642E866A07C7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Allure.XUnit.Reporters", "Allure.XUnit.Reporters\Allure.XUnit.Reporters.csproj", "{5A5F20A0-9728-4554-8CD7-850698A0061F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -104,6 +109,14 @@ Global
 		{77893A8D-4313-4211-AFF1-642E866A07C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77893A8D-4313-4211-AFF1-642E866A07C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77893A8D-4313-4211-AFF1-642E866A07C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Adapters|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Adapters|Any CPU.Build.0 = Debug|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Commons|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Commons|Any CPU.Build.0 = Debug|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A5F20A0-9728-4554-8CD7-850698A0061F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -118,6 +131,7 @@ Global
 		{38CF463E-F564-477D-A853-407F0648E0DD} = {138A76FC-B163-423C-8FF8-D374F1C7EC2F}
 		{81F804C5-C437-4079-9731-97C6A2A86C48} = {D0D75FDF-4884-4AC1-868F-B3F248CB74ED}
 		{77893A8D-4313-4211-AFF1-642E866A07C7} = {D0D75FDF-4884-4AC1-868F-B3F248CB74ED}
+		{5A5F20A0-9728-4554-8CD7-850698A0061F} = {138A76FC-B163-423C-8FF8-D374F1C7EC2F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {54ACFEA9-DB76-4FC0-B216-B8033996DB79}


### PR DESCRIPTION
This PR lifts the limitation described in #368. Some additional changes also have been made to accommodate xunit's 2.5.0 breaking change on how reporter assemblies are discovered [[1]] and to fix some issues with NuGet packaging.

## Context

### Reporters incompatibility

xUnit.net allows only one runner reporter to be executed at a time. A reporter can be specified explicitly by the user or selected implicitly by xUnit based on environmental availability. By default, xUnit selects the first reporter that is environmentally enabled.

If more than one reporter is environmentally enabled, xUnit selects the first one and ignores the rest. Since Allure.XUnit is implemented as an always enabled reporter, there might be a chance another reporter is preferred by xUnit over it.

Typical scenario is running xUnit tests in a CI environment, e.g., in TeamCity. In such a case the `teamcity` reporter is enabled together with `allure` and xUnit may select any of them.

It is a quite common scenario though to generate allure report in a CI environment while reporting test results to the CI system as well. This PR adds support for it.

## Implementation

Reporters in xUnit.net are easily composable. The trickiest part is to discover the reporter class. We try to find the one that would've been used by xUnit if Allure.XUnit wasn't present. If such reporter exists, it is composed with Allure.XUnit. Otherwise, Allure.XUnit is used alone.

In most cases this is an acceptable approach. It allows automatically detects CI environments and report test results both to allure and the CI server.

However, some flexibility is allowed through the following property in `allureConfig.json`:

```json
{
    "allure": {
        "xunitRunnerReporter": "auto|none|<switch>|<AQ-classname>"
    }
}
```

  - `auto` is the default.
  - To report to allure only, the `none` value should be used.
  - The reporter can be specified explicitly by its switch.
  - The reporter can be specified explicitly by its assembly qualified class name to skip time consuming discovery algorithm and use the given reporter class instead.

In case of `auto` or `<switch>` values the following discovery algorithm is used:

1. Iterate through the assemblies in the current application domain (assembly load context in .NET Core, see [[2]]) omitting obviously unfit ones.
2. For each assembly iterate through its types searching for Xunit.IRunnerReporter implementations.
3. For each found implementation create an instance and check if it should be used:
    1. In the `auto` mode the reporter is selected if it is environmentally enabled.
    2. If the `<switch>` mode the reporter is selected if its runner switch matches the specified one (using case-insensitive comparison).

### Examples

#### Examples 1: disable an additional reporter leaving only Allure.XUnit's one

```json
{
    "allure": {
        "xunitRunnerReporter": "none"
    }
}
```

#### Example 2: use the `teamcity` reporter together with Allure.XUnit:

```json
{
    "allure": {
        "xunitRunnerReporter": "teamcity"
    }
}
```

#### Example 3: use the assembly qualified class name to quickly create and use the `teamcity` reporter together with Allure.XUnit:

```json
{
    "allure": {
        "xunitRunnerReporter": "Xunit.Runner.Reporters.TeamCityReporter, xunit.runner.reporters.netcoreapp10, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c"
    }
}
```

> [!NOTE]
> Make sure you use the correct version of the assembly.

## Other changes

### Adapting to xUnit.net 2.5.0 breaking change

Starting from 2.5.0, xUnit.net only considers assemblies matching the `*reporters*.dll` pattern. This PR moves the reporter class into the new project `Allure.XUnit.Reporters` that produces the `Allure.XUnit.reporters.dll` assembly. This assembly is packed together with Allure.XUnit.dll in the Allure.XUnit package, so the user experience shouldn't be affected.

### Introduction of Directory.Build.props
The Directory.Build.props file was introduced to reduce the boilerplate code in `.csproj` files [[3]]. It contains the common metadata (e.g., the version), the common properties, reference to the source link and some defaults.

### Increase AspectInjector's version to 2.8.2
There is a bug in the underlying `Mono.Cecil` dependency that excludes the `PdbChecksum` debug header entry from a generated assembly. Pdb's for such assemblies can't be validated by NuGet and the corresponding `.snupkg` files are always rejected. See also jbevain/cecil#610. This was fixed in jbevain/cecil#810.

The new version of AspectInjector depends on Mono.Cecil 0.11.5 that includes the fix.

### Fully deterministic build

This PR enables fully deterministic build via the `-p:ContinuousIntegrationBuild=true` in the publishing pipeline [[4]].

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[1]: https://xunit.net/releases/v2/2.5.0
[2]: https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/AppDomain.cs#L231
[3]: https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022
[4]: https://github.com/dotnet/sourcelink/blob/main/docs/README.md#continuousintegrationbuild
[cla]: https://cla-assistant.io/accept/allure-framework/allure2

Fixes #368
