### PR TITLE
Selective run support: commons, nunit, xunit

### DIFF
--- a/Allure.NUnit/Core/AllureExtensions.cs
+++ b/Allure.NUnit/Core/AllureExtensions.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Allure.Net.Commons;
+using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
 
 namespace NUnit.Allure.Core
@@ -203,6 +204,15 @@ namespace NUnit.Allure.Core
                 throw;
             }
         }
+
+        internal const string DESELECTED_BY_TESTPLAN_KEY
+            = "DESELECTED_BY_TESTPLAN";
+
+        static internal void Deselect(this ITest test) =>
+            test.Properties.Add(DESELECTED_BY_TESTPLAN_KEY, true);
+
+        static internal bool IsDeselected(this ITest test) =>
+            test.Properties.ContainsKey(DESELECTED_BY_TESTPLAN_KEY);
 
         [Obsolete(
             "Use AllureLifecycle.AddScreenDiff instance method instead to " +

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -191,12 +191,7 @@ namespace NUnit.Allure.Core
         }
 
         static bool IsSelectedByTestPlan(TestResult testResult) =>
-            TestPlan.Value.IsMatch(
-                testResult.fullName,
-                AllureTestPlan.GetAllureId(
-                    testResult.labels ?? Enumerable.Empty<Label>()
-                )
-            );
+            TestPlan.Value.IsMatch(testResult);
 
         IEnumerable<AllureTestCaseAttribute> IterateAllAllureAttribites() =>
             this._test.Method

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -33,9 +33,6 @@ namespace NUnit.Allure.Core
 
         private static AllureLifecycle AllureLifecycle => AllureLifecycle.Instance;
 
-        static Lazy<AllureTestPlan> TestPlan { get; }
-            = new(AllureTestPlan.FromEnvironment);
-
         internal void StartTestContainer()
         {
             AllureLifecycle.StartTestContainer(new()
@@ -191,7 +188,7 @@ namespace NUnit.Allure.Core
         }
 
         static bool IsSelectedByTestPlan(TestResult testResult) =>
-            TestPlan.Value.IsMatch(testResult);
+            AllureLifecycle.TestPlan.IsSelected(testResult);
 
         IEnumerable<AllureTestCaseAttribute> IterateAllAllureAttribites() =>
             this._test.Method

--- a/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanProviderTests.cs
+++ b/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanProviderTests.cs
@@ -1,0 +1,120 @@
+﻿using Allure.Net.Commons.TestPlan;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Text;
+
+namespace Allure.Net.Commons.Tests.SelectiveRunTests
+{
+    class TestPlanProviderTests
+    {
+        private string testPlanPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.testPlanPath = Path.GetTempFileName();
+            File.WriteAllText(
+                this.testPlanPath,
+                "{\"tests\": [{\"id\": \"100\"}]}",
+                Encoding.UTF8
+            );
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(this.testPlanPath))
+            {
+                File.Delete(this.testPlanPath);
+            }
+            Environment.SetEnvironmentVariable("ALLURE_TESTPLAN_PATH", null);
+            Environment.SetEnvironmentVariable("AS_TESTPLAN_PATH", null);
+        }
+
+        [Test]
+        public void TestPlanCreatedFromFileByNewEnvName()
+        {
+            Environment.SetEnvironmentVariable(
+                "ALLURE_TESTPLAN_PATH",
+                this.testPlanPath
+            );
+
+            var testplan = AllureTestPlan.FromEnvironment();
+
+            Assert.That(
+                testplan.Tests,
+                Is.EqualTo(
+                    new[] { new AllureTestPlanItem() { Id = "100" } }
+                )
+            );
+        }
+
+        [Test]
+        public void TestPlanCreatedFromFileByOldEnvName()
+        {
+            Environment.SetEnvironmentVariable(
+                "AS_TESTPLAN_PATH",
+                this.testPlanPath
+            );
+
+            var testplan = AllureTestPlan.FromEnvironment();
+
+            Assert.That(
+                testplan.Tests,
+                Is.EqualTo(
+                    new[] { new AllureTestPlanItem() { Id = "100" } }
+                )
+            );
+        }
+
+        [Test]
+        public void DefaultTestPlanCreatedIfNoEnvVarDefined()
+        {
+            Assert.That(
+                AllureTestPlan.FromEnvironment(),
+                Is.SameAs(
+                    AllureTestPlan.DEFAULT_TESTPLAN
+                )
+            );
+        }
+
+        [Test]
+        public void DefaultTestPlanCreatedIfFIleDoesntExist()
+        {
+            Environment.SetEnvironmentVariable(
+                "ALLURE_TESTPLAN_PATH",
+                Guid.NewGuid().ToString()
+            );
+
+            Assert.That(
+                AllureTestPlan.FromEnvironment(),
+                Is.SameAs(
+                    AllureTestPlan.DEFAULT_TESTPLAN
+                )
+            );
+        }
+
+        [Test]
+        public void IfBothEnvVarsPresentNewIsPreferred()
+        {
+            Environment.SetEnvironmentVariable(
+                "AS_TESTPLAN_PATH",
+                Guid.NewGuid().ToString()
+            );
+            Environment.SetEnvironmentVariable(
+                "ALLURE_TESTPLAN_PATH",
+                this.testPlanPath
+            );
+
+            var testplan = AllureTestPlan.FromEnvironment();
+
+            Assert.That(
+                testplan.Tests,
+                Is.EqualTo(
+                    new[] { new AllureTestPlanItem() { Id = "100" } }
+                )
+            );
+        }
+    }
+}

--- a/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
+++ b/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
@@ -187,6 +187,42 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             );
         }
 
+        [Test]
+        public void TestResultMatchShorthandTest(
+            [Values(
+                "[]",
+                "[{\"id\": \"100\"}]",
+                "[{\"selector\": \"a\"}]",
+                "[{\"selector\": \"a\", \"id\": \"100\"}]",
+                "[{\"id\": \"100\"}, {\"id\": \"101\"}]",
+                "[{\"selector\": \"a\"}, {\"selector\": \"b\"}]",
+                "[{\"id\": \"100\"}, {\"selector\": \"a\"}]",
+                "[{\"selector\": \"a\", \"id\": \"100\"}, {\"selector\": \"b\", \"id\": \"101\"}]"
+            )] string testPlanItemsJson,
+            [Values("a", "b", "c")] string fullNameOfTestCase,
+            [Values("100", "101", "102")] string allureIdOfTestCase
+        )
+        {
+            var testResult = new TestResult
+            {
+                fullName = fullNameOfTestCase,
+                labels = allureIdOfTestCase is null ? new() : new()
+                {
+                    new() { name = "ALLURE_ID", value = allureIdOfTestCase }
+                }
+            };
+            var testPlan = AllureTestPlan.FromJson(
+                $"{{\"tests\": {testPlanItemsJson}}}"
+            );
+
+            Assert.That(
+                testPlan.IsMatch(testResult),
+                Is.EqualTo(
+                    testPlan.IsMatch(fullNameOfTestCase, allureIdOfTestCase)
+                )
+            );
+        }
+
         [TestCase(new string[] { }, null)]
         [TestCase(new[] { "ALLURE_ID", "100" }, "100")]
         [TestCase(new[] { "l1", "v1" }, null)]

--- a/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
+++ b/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
@@ -1,5 +1,6 @@
 ﻿using Allure.Net.Commons.TestPlan;
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
 
 #nullable enable
@@ -11,14 +12,14 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
         [TestCase("null")]
         [TestCase("{}")]
         [TestCase("{\"tests\": []}")]
-        public void EmptyTestPlan(string json)
+        public void EmptyTestPlanEnablesAllTests(string json)
         {
             var testPlan = AllureTestPlan.FromJson(json);
 
             Assert.That(testPlan, Is.Not.Null);
             Assert.That(
                 testPlan.IsMatch("", null),
-                Is.False
+                Is.True
             );
         }
 
@@ -217,22 +218,19 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
         {
             Assert.That(
                 AllureTestPlan.GetAllureId(
-                    CreateTestCaseWithLabels(labels)
+                    CreateLabels(labels)
                 ),
                 Is.EqualTo(expectedAllureId)
             );
         }
 
-        static TestResult CreateTestCaseWithLabels(params string[] labels) =>
-            new()
-            {
-                labels = Enumerable.Range(0, labels.Length / 2).Select(
-                    i => new Label()
-                    {
-                        name = labels[2 * i],
-                        value = labels[2 * i + 1]
-                    }
-                ).ToList()
-            };
+        static IEnumerable<Label> CreateLabels(params string[] labels) =>
+            Enumerable.Range(0, labels.Length / 2).Select(
+                i => new Label()
+                {
+                    name = labels[2 * i],
+                    value = labels[2 * i + 1]
+                }
+            );
     }
 }

--- a/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
+++ b/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
@@ -18,7 +18,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
 
             Assert.That(testPlan, Is.Not.Null);
             Assert.That(
-                testPlan.IsMatch("", null),
+                testPlan.IsSelected("", null),
                 Is.True
             );
         }
@@ -35,7 +35,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     "",
                     allureIdOfTestCase
                 ),
@@ -56,7 +56,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     fullNameOfTestCase,
                     null
                 ),
@@ -81,7 +81,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     fullNameOfTestCase,
                     allureIdOfTestCase
                 ),
@@ -102,7 +102,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     "",
                     allureIdOfTestCase
                 ),
@@ -123,7 +123,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     fullNameOfTestCase,
                     null
                 ),
@@ -148,7 +148,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     fullNameOfTestCase,
                     allureIdOfTestCase
                 ),
@@ -179,7 +179,7 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             var testPlan = AllureTestPlan.FromJson(testPlanJson);
 
             Assert.That(
-                testPlan.IsMatch(
+                testPlan.IsSelected(
                     fullNameOfTestCase,
                     allureIdOfTestCase
                 ),
@@ -216,9 +216,9 @@ namespace Allure.Net.Commons.Tests.SelectiveRunTests
             );
 
             Assert.That(
-                testPlan.IsMatch(testResult),
+                testPlan.IsSelected(testResult),
                 Is.EqualTo(
-                    testPlan.IsMatch(fullNameOfTestCase, allureIdOfTestCase)
+                    testPlan.IsSelected(fullNameOfTestCase, allureIdOfTestCase)
                 )
             );
         }

--- a/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
+++ b/Allure.Net.Commons.Tests/SelectiveRunTests/TestPlanTests.cs
@@ -1,0 +1,238 @@
+﻿using Allure.Net.Commons.TestPlan;
+using NUnit.Framework;
+using System.Linq;
+
+#nullable enable
+
+namespace Allure.Net.Commons.Tests.SelectiveRunTests
+{
+    class TestPlanTests
+    {
+        [TestCase("null")]
+        [TestCase("{}")]
+        [TestCase("{\"tests\": []}")]
+        public void EmptyTestPlan(string json)
+        {
+            var testPlan = AllureTestPlan.FromJson(json);
+
+            Assert.That(testPlan, Is.Not.Null);
+            Assert.That(
+                testPlan.IsMatch("", null),
+                Is.False
+            );
+        }
+
+        [TestCase(null, false)]
+        [TestCase("100", true)]
+        [TestCase("101", false)]
+        public void TestPlanWithIdEntry(
+            string allureIdOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson = "{\"tests\": [{\"id\": \"100\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    "",
+                    allureIdOfTestCase
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase("a", true)]
+        [TestCase("A", false)]
+        [TestCase("aa", false)]
+        public void TestPlanWithSelectorEntry(
+            string fullNameOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson =
+                "{\"tests\": [{\"selector\": \"a\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    fullNameOfTestCase,
+                    null
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase("a", "100", true)]
+        [TestCase("b", "100", true)]
+        [TestCase("a", "101", true)]
+        [TestCase("a", null, true)]
+        [TestCase("b", "101", false)]
+        [TestCase("b", null, false)]
+        public void TestPlanWithIdAndSelectorEntry(
+            string fullNameOfTestCase,
+            string allureIdOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson =
+                "{\"tests\": [{\"selector\": \"a\", \"id\": \"100\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    fullNameOfTestCase,
+                    allureIdOfTestCase
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase("100", true)]
+        [TestCase("101", true)]
+        [TestCase("102", false)]
+        public void TestPlanWithMultipleIdEntries(
+            string allureIdOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson =
+                "{\"tests\": [{\"id\": \"100\"}, {\"id\": \"101\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    "",
+                    allureIdOfTestCase
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase("a", true)]
+        [TestCase("b", true)]
+        [TestCase("c", false)]
+        public void TestPlanWithMultipleSelectorEntries(
+            string fullNameOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson =
+                "{\"tests\": [{\"selector\": \"a\"}, {\"selector\": \"b\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    fullNameOfTestCase,
+                    null
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase("a", "100", true)]
+        [TestCase("b", "100", true)]
+        [TestCase("a", "101", true)]
+        [TestCase("a", null, true)]
+        [TestCase("b", "101", false)]
+        [TestCase("b", null, false)]
+        public void TestPlanWithMultipleDifferentEntries(
+            string fullNameOfTestCase,
+            string allureIdOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson =
+                "{\"tests\": [{\"id\": \"100\"}, {\"selector\": \"a\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    fullNameOfTestCase,
+                    allureIdOfTestCase
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase("a", null, true)]
+        [TestCase("a", "100", true)]
+        [TestCase("a", "101", true)]
+        [TestCase("a", "102", true)]
+        [TestCase("b", null, true)]
+        [TestCase("b", "100", true)]
+        [TestCase("b", "101", true)]
+        [TestCase("b", "102", true)]
+        [TestCase("c", null, false)]
+        [TestCase("c", "100", true)]
+        [TestCase("c", "101", true)]
+        [TestCase("c", "102", false)]
+        public void TestPlanWithMultipleFullEntries(
+            string fullNameOfTestCase,
+            string allureIdOfTestCase,
+            bool expectedMatch
+        )
+        {
+            var testPlanJson =
+                "{\"tests\": [{\"selector\": \"a\", \"id\": \"100\"}, {\"selector\": \"b\", \"id\": \"101\"}]}";
+            var testPlan = AllureTestPlan.FromJson(testPlanJson);
+
+            Assert.That(
+                testPlan.IsMatch(
+                    fullNameOfTestCase,
+                    allureIdOfTestCase
+                ),
+                Is.EqualTo(expectedMatch)
+            );
+        }
+
+        [TestCase(new string[] { }, null)]
+        [TestCase(new[] { "ALLURE_ID", "100" }, "100")]
+        [TestCase(new[] { "l1", "v1" }, null)]
+        [TestCase(new[] { "AS_ID", "100" }, "100")]
+        [TestCase(new[] { "allure_id", "100" }, "100")]
+        [TestCase(new[] { "as_id", "100" }, "100")]
+        [TestCase(new[]
+        {
+            "l", "v",
+            "ALLURE_ID", "100"
+        }, "100")]
+        [TestCase(new[]
+        {
+            "l", "v",
+            "AS_ID", "100"
+        }, "100")]
+        [TestCase(new[]
+        {
+            "allure_id", "100",
+            "ALLURE_ID", "101",
+            "AS_ID", "102"
+        }, "100")]
+        [TestCase(new[]
+        {
+            "AS_ID", "100",
+            "ALLURE_ID", "101"
+        }, "101")]
+        public void GetAllureIdTest(string[] labels, string? expectedAllureId)
+        {
+            Assert.That(
+                AllureTestPlan.GetAllureId(
+                    CreateTestCaseWithLabels(labels)
+                ),
+                Is.EqualTo(expectedAllureId)
+            );
+        }
+
+        static TestResult CreateTestCaseWithLabels(params string[] labels) =>
+            new()
+            {
+                labels = Enumerable.Range(0, labels.Length / 2).Select(
+                    i => new Label()
+                    {
+                        name = labels[2 * i],
+                        value = labels[2 * i + 1]
+                    }
+                ).ToList()
+            };
+    }
+}

--- a/Allure.Net.Commons/AllureConstants.cs
+++ b/Allure.Net.Commons/AllureConstants.cs
@@ -10,5 +10,11 @@
         public const string TEST_RESULT_CONTAINER_FILE_SUFFIX = "-container.json";
         public static string TEST_RUN_FILE_SUFFIX = "-testrun.json";
         public const string ATTACHMENT_FILE_SUFFIX = "-attachment";
+
+        public const string OLD_ALLURE_ID_LABEL_NAME = "AS_ID";
+        public const string NEW_ALLURE_ID_LABEL_NAME = "ALLURE_ID";
+
+        public const string OLD_ALLURE_TESTPLAN_ENV_NAME = "AS_TESTPLAN_PATH";
+        public const string NEW_ALLURE_TESTPLAN_ENV_NAME = "ALLURE_TESTPLAN_PATH";
     }
 }

--- a/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
+++ b/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
@@ -37,7 +37,9 @@ public class AllureTestPlan
     /// </param>
     /// <returns>true if the test should be executed. false otherwise.</returns>
     public bool IsMatch(string fullName, string? allureId) =>
-        this.IsFullNameMatch(fullName) || this.IsAllureIdMatch(allureId);
+        this.IsDefaultTestplanMatch()
+            || this.IsFullNameMatch(fullName)
+            || this.IsAllureIdMatch(allureId);
 
     /// <summary>
     /// Creates the testplan from a JSON string.
@@ -62,12 +64,12 @@ public class AllureTestPlan
     }
 
     /// <summary>
-    /// Extracts the id from a test result. If there is no id associated,
-    /// returns null.
+    /// Finds an Allure id in a sequence of labels. If no id exists, returns
+    /// null.
     /// </summary>
-    public static string? GetAllureId(TestResult testResult) =>
-        FindLabel(testResult, AllureConstants.NEW_ALLURE_ID_LABEL_NAME)
-            ?? FindLabel(testResult, AllureConstants.OLD_ALLURE_ID_LABEL_NAME);
+    public static string? GetAllureId(IEnumerable<Label> labels) =>
+        FindLabel(labels, AllureConstants.NEW_ALLURE_ID_LABEL_NAME)
+            ?? FindLabel(labels, AllureConstants.OLD_ALLURE_ID_LABEL_NAME);
 
     /// <summary>
     /// A testplan that doesn't filter any test.
@@ -93,8 +95,8 @@ public class AllureTestPlan
             File.ReadAllText(testPlanPath, Encoding.UTF8)
         );
 
-    static string? FindLabel(TestResult testResult, string labelName) =>
-        testResult.labels.FirstOrDefault(
+    static string? FindLabel(IEnumerable<Label> labels, string labelName) =>
+        labels.FirstOrDefault(
             l => labelName.Equals(l.name, StringComparison.OrdinalIgnoreCase)
         )?.value;
 
@@ -117,6 +119,8 @@ public class AllureTestPlan
             StringComparer.Ordinal
         );
     }
+
+    bool IsDefaultTestplanMatch() => !this.tests.Any();
 
     bool IsAllureIdMatch(string? allureId) =>
         allureId is not null && this.allIds.Contains(allureId);

--- a/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
+++ b/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
@@ -36,17 +36,17 @@ public class AllureTestPlan
     /// Use <see cref="GetAllureId"/> to get it from the test result.
     /// </param>
     /// <returns>true if the test should be executed. false otherwise.</returns>
-    public bool IsMatch(string fullName, string? allureId) =>
+    public bool IsSelected(string fullName, string? allureId) =>
         this.IsDefaultTestplanMatch()
             || this.IsFullNameMatch(fullName)
             || this.IsAllureIdMatch(allureId);
 
     /// <summary>
-    /// A shorthand for <see cref="IsMatch(string, string?)"/> with the
+    /// A shorthand for <see cref="IsSelected(string, string?)"/> with the
     /// fullName and the allure id taken from the provided test result.
     /// </summary>
-    public bool IsMatch(TestResult testResult) =>
-        this.IsMatch(
+    public bool IsSelected(TestResult testResult) =>
+        this.IsSelected(
             testResult.fullName,
             GetAllureId(testResult.labels)
         );

--- a/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
+++ b/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
@@ -42,6 +42,16 @@ public class AllureTestPlan
             || this.IsAllureIdMatch(allureId);
 
     /// <summary>
+    /// A shorthand for <see cref="IsMatch(string, string?)"/> with the
+    /// fullName and the allure id taken from the provided test result.
+    /// </summary>
+    public bool IsMatch(TestResult testResult) =>
+        this.IsMatch(
+            testResult.fullName,
+            GetAllureId(testResult.labels)
+        );
+
+    /// <summary>
     /// Creates the testplan from a JSON string.
     /// </summary>
     public static AllureTestPlan FromJson(string jsonContent) =>

--- a/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
+++ b/Allure.Net.Commons/TestPlan/AllureTestPlan.cs
@@ -1,0 +1,126 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+#nullable enable
+
+namespace Allure.Net.Commons.TestPlan;
+
+/// <summary>
+/// Used by integrations to enable selective run of tests.
+/// </summary>
+public class AllureTestPlan
+{
+    /// <summary>
+    /// Testplan entries that denote tests included in the run.
+    /// </summary>
+    public List<AllureTestPlanItem> Tests
+    {
+        get => this.tests;
+        set
+        {
+            this.tests = value ?? new();
+            this.RecreateFilters();
+        }
+    }
+
+    /// <summary>
+    /// Used by integrations to check if a test is selected by the testplan.
+    /// </summary>
+    /// <param name="fullName">A fullName of the test.</param>
+    /// <param name="allureId">
+    /// An identifier of the test case (if any).
+    /// Use <see cref="GetAllureId"/> to get it from the test result.
+    /// </param>
+    /// <returns>true if the test should be executed. false otherwise.</returns>
+    public bool IsMatch(string fullName, string? allureId) =>
+        this.IsFullNameMatch(fullName) || this.IsAllureIdMatch(allureId);
+
+    /// <summary>
+    /// Creates the testplan from a JSON string.
+    /// </summary>
+    public static AllureTestPlan FromJson(string jsonContent) =>
+        JsonConvert.DeserializeObject<AllureTestPlan>(
+            jsonContent,
+            new JsonSerializerSettings()
+            {
+                ObjectCreationHandling = ObjectCreationHandling.Replace,
+            }
+        ) ?? DEFAULT_TESTPLAN;
+
+    /// <summary>
+    /// Creates the testplan from the file pointed by the environment variable.
+    /// </summary>
+    /// <exception cref="NotImplementedException"></exception>
+    public static AllureTestPlan FromEnvironment()
+    {
+        var testPlanPath = ResolveTestPlanPath();
+        return GetTestPlanByPath(testPlanPath);
+    }
+
+    /// <summary>
+    /// Extracts the id from a test result. If there is no id associated,
+    /// returns null.
+    /// </summary>
+    public static string? GetAllureId(TestResult testResult) =>
+        FindLabel(testResult, AllureConstants.NEW_ALLURE_ID_LABEL_NAME)
+            ?? FindLabel(testResult, AllureConstants.OLD_ALLURE_ID_LABEL_NAME);
+
+    /// <summary>
+    /// A testplan that doesn't filter any test.
+    /// </summary>
+    public static readonly AllureTestPlan DEFAULT_TESTPLAN = new();
+
+    static string? ResolveTestPlanPath() =>
+        new[]
+        {
+            AllureConstants.NEW_ALLURE_TESTPLAN_ENV_NAME,
+            AllureConstants.OLD_ALLURE_TESTPLAN_ENV_NAME
+        }.Select(Environment.GetEnvironmentVariable).Where(
+            ev => !string.IsNullOrWhiteSpace(ev)
+        ).FirstOrDefault();
+
+    static AllureTestPlan GetTestPlanByPath(string? testPlanPath) =>
+        testPlanPath is null || !File.Exists(testPlanPath)
+            ? DEFAULT_TESTPLAN
+            : ReadTestPlanFromFile(testPlanPath);
+
+    static AllureTestPlan ReadTestPlanFromFile(string testPlanPath) =>
+        FromJson(
+            File.ReadAllText(testPlanPath, Encoding.UTF8)
+        );
+
+    static string? FindLabel(TestResult testResult, string labelName) =>
+        testResult.labels.FirstOrDefault(
+            l => labelName.Equals(l.name, StringComparison.OrdinalIgnoreCase)
+        )?.value;
+
+    List<AllureTestPlanItem> tests = new();
+    HashSet<string> allIds = new();
+    HashSet<string> allSelectors = new();
+
+    void RecreateFilters()
+    {
+        this.allIds = new HashSet<string>(
+            from entry in this.tests
+            where entry.Id is not null
+            select entry.Id,
+            StringComparer.Ordinal
+        );
+        this.allSelectors = new HashSet<string>(
+            from entry in this.tests
+            where entry.Selector is not null
+            select entry.Selector,
+            StringComparer.Ordinal
+        );
+    }
+
+    bool IsAllureIdMatch(string? allureId) =>
+        allureId is not null && this.allIds.Contains(allureId);
+
+    bool IsFullNameMatch(string fullName) =>
+        this.allSelectors.Contains(fullName);
+}

--- a/Allure.Net.Commons/TestPlan/AllureTestPlanItem.cs
+++ b/Allure.Net.Commons/TestPlan/AllureTestPlanItem.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+
+namespace Allure.Net.Commons.TestPlan;
+
+public record class AllureTestPlanItem
+{
+    public string? Id { get; set; }
+
+    public string? Selector { get; set; }
+}

--- a/Allure.XUnit/AllureMessageSink.cs
+++ b/Allure.XUnit/AllureMessageSink.cs
@@ -15,10 +15,10 @@ namespace Allure.XUnit
     public class AllureMessageSink :
         DefaultRunnerReporterWithTypesMessageHandler
     {
-        static readonly Lazy<AllureTestPlan> lazyTestPlan
-            = new(AllureTestPlan.FromEnvironment);
-
-        static AllureTestPlan TestPlan { get => lazyTestPlan.Value; }
+        static AllureTestPlan TestPlan
+        {
+            get => AllureLifecycle.Instance.TestPlan;
+        }
 
         static AllureContext AllureContext
         {
@@ -55,7 +55,7 @@ namespace Allure.XUnit
         {
             var associatedData = this.GetOrCreateTestData(test);
             var testResult = AllureXunitHelper.CreateTestResultByTest(test);
-            var isSelected = TestPlan.IsMatch(testResult);
+            var isSelected = TestPlan.IsSelected(testResult);
             associatedData.TestResult = testResult;
             associatedData.IsSelected = isSelected;
             return isSelected;

--- a/Allure.XUnit/AllureXunitHelper.cs
+++ b/Allure.XUnit/AllureXunitHelper.cs
@@ -60,19 +60,13 @@ namespace Allure.Xunit
             return container;
         }
 
-        internal static TestResult StartStaticAllureTestCase(ITest test)
-        {
-            var testResult = CreateTestResultByTest(test);
-            AllureLifecycle.Instance.StartTestCase(testResult);
-            return testResult;
-        }
-
-        internal static TestResult StartAllureTestCase(ITest test)
-        {
-            var testResult = CreateTestResultByTest(test);
-            AllureLifecycle.Instance.StartTestCase(testResult);
-            return testResult;
-        }
+        internal static void StartAllureTestCase(
+            ITest test,
+            TestResult? testResult
+        ) =>
+            AllureLifecycle.Instance.StartTestCase(
+                testResult ?? CreateTestResultByTest(test)
+            );
 
         internal static void ApplyTestFailure(IFailureInformation failure)
         {
@@ -149,19 +143,8 @@ namespace Allure.Xunit
             AllureLifecycle.Instance.WriteTestContainer();
         }
 
-        internal static void ReportSkippedTestCase(ITestCase testCase)
-        {
-            var testResult = CreateTestResultByTestCase(testCase);
-            ApplyTestSkip(testResult, testCase.SkipReason);
-            AllureLifecycle.Instance.StartTestCase(testResult);
-            ReportCurrentTestCase();
-        }
-
-        static TestResult CreateTestResultByTest(ITest test) =>
+        internal static TestResult CreateTestResultByTest(ITest test) =>
             CreateTestResult(test.TestCase, test.DisplayName);
-
-        static TestResult CreateTestResultByTestCase(ITestCase testCase) =>
-            CreateTestResult(testCase, testCase.DisplayName);
 
         static TestResult CreateTestResult(
             ITestCase testCase,
@@ -420,6 +403,9 @@ namespace Allure.Xunit
                 testCase.TestMethodArguments
             );
         }
+
+        static TestResult CreateTestResultByTestCase(ITestCase testCase) =>
+            CreateTestResult(testCase, testCase.DisplayName);
 
         [Obsolete(OBS_MSG_UNINTENDED_PUBLIC)]
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/Allure.XUnit/AllureXunitTestData.cs
+++ b/Allure.XUnit/AllureXunitTestData.cs
@@ -1,10 +1,14 @@
 using Allure.Net.Commons;
 
+#nullable enable
+
 namespace Allure.XUnit
 {
     class AllureXunitTestData
     {
-        public AllureContext Context { get; set; }
-        public object[] Arguments { get; set; }
+        public AllureContext? Context { get; set; }
+        public object[]? Arguments { get; set; }
+        public TestResult? TestResult { get; set; }
+        public bool IsSelected { get; set; } = true;
     }
 }


### PR DESCRIPTION
### Context
Selective test run is essential for the future allure 3 release as well as for TestOps users. This PR adds common support for selective run and implements test selection by a test plan for allure-nunit and allure-xunit.

### New API

The following API was added to be used by integration authors to access a test plan and check if a test is selected to run:

```CSharp
// The current test plan
Allure.Net.Commons.TestPlan.AllureTestPlan Allure.Net.Commons.AllureLifecycle.TestPlan { get; }

// Checks if a test with the specified fullName and allureId (optional) is selected by the test plan
bool Allure.Net.Commons.TestPlan.AllureTestPlan.IsSelected(string fullName, string? allureId);

// Checks if a test is selected by the test plan
bool Allure.Net.Commons.TestPlan.AllureTestPlan.IsSelected(TestResult testResult);

// Extracts an allure id from a sequence of labels
bool Allure.Net.Commons.TestPlan.AllureTestPlan.GetAllureId(IEnumerable<Label> labels);
```

### Implementation details
A test plan instance is lazily created from the file denoted by the `ALLURE_TESTPLAN_PATH` environment variable. If the variable isn't defined, the legacy `AS_TESTPLAN_PATH` is used. If it isn't defined either, the default test plan is created that doesn't filter any test.

Lazy initialization of a test plan allows to set the environment variable prior to actual test selection.

Integration checks whether a given test should be included in the run by passing the full name and the allure id to `AllureTestPlan.IsSelected`. Alternatevely, it may pass the test result object with fullName and labels specified.

The `GetAllureId` function helps to find the id in a sequence of labels using the following algorithm:

  - If the `ALLURE_ID` label exists in the sequence, its value is returned.
  - Otherwise, if the `AS_ID` label exists in the sequence, its value is returned.
  - Otherwise, null is returned.

### Selective run in allure-nunit

NUnit allows to skip a test via the `Assert.Ignore()` call (it basically throws IgnoreException; the engine catches it and skips the test). Since allure-nunit's code is run mostly in a test context of NUnit, `Assert.Ignore()` just naturally works.

The only thing that is required for this to work is to move attribute-to-label conversions before a test plan selection check to make allureId available early. 

### Selective run in allure-xunit

xUnit.net only allows tests to be skipped via the attributes API (the `Ignore` attribute or the `Skip` parameter of the `Fact` attribute). It passes the skip message all the way to XunitTestRunner where it's used to decide on whether the test should be skipped [[1]]. The only way to skip the test is to modify this message.

Since we are already patching XunitTestRunner's constructor by Harmony to get test arguments, we just add one more patch (a prefix patch) to change the skipReason parameter if the test should be skipped because of a test plan.

#### Known limitation
In a rare case XunitTestRunner's ctor gets inlined by the CLR the selective run feature stops working. The workaround is to use Debug configuration when testing the code.

We're tracking the work to prevent this in #369.

### API obsolescence

The following API methods are now obsoleted and might be removed in a future release:

```CSharp
void NUnit.Allure.Core.AllureNUnitHelper.SaveOneTimeResultToContext();
void NUnit.Allure.Core.AllureNUnitHelper.AddOneTimeSetupResult();
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

Closes #372 

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
[1]: https://github.com/xunit/xunit/blob/8ae0d067bb8f427f38c5524b4f3c47f99e844f77/src/xunit.execution/Sdk/Frameworks/Runners/TestRunner.cs#L136