### PR TITLE
Allure-specflow: selective run support

### DIFF
--- a/Allure.Features/Allure.Features.csproj
+++ b/Allure.Features/Allure.Features.csproj
@@ -11,8 +11,11 @@
         <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
         <PackageReference Include="SpecFlow" Version="3.9.74" />
         <PackageReference Include="SpecFlow.SharedSteps" Version="3.0.7" />
-        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
-        <PackageReference Include="SpecFlow.NUnit" Version="3.9.8" />
+        
+        <!-- SpecFlow.SharedSteps doesn't work with SpecFlow.Tools.MsBuild.Generation v3.9.58+  -->
+        <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.52" />
+        
+        <PackageReference Include="SpecFlow.NUnit" Version="3.9.52" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\Allure.Net.Commons\Allure.Net.Commons.csproj" />

--- a/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
+++ b/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
@@ -26,6 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="Lib.Harmony" Version="2.3.0-prerelease.2" />
         <PackageReference Include="SpecFlow" Version="[3.9.8, 3.10)" />
         <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     </ItemGroup>

--- a/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
+++ b/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0</TargetFrameworks>
         <IsPackable>true</IsPackable>
         <Nullable>enable</Nullable>
         <PackageId>Allure.SpecFlow</PackageId>

--- a/Allure.SpecFlowPlugin/AllureBindingInvoker.cs
+++ b/Allure.SpecFlowPlugin/AllureBindingInvoker.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Collections.Specialized;
 using Allure.Net.Commons;
+using Allure.SpecFlowPlugin.SelectiveRun;
 using TechTalk.SpecFlow;
 using TechTalk.SpecFlow.Bindings;
 using TechTalk.SpecFlow.Configuration;
 using TechTalk.SpecFlow.ErrorHandling;
 using TechTalk.SpecFlow.Infrastructure;
 using TechTalk.SpecFlow.Tracing;
-
+using TechTalk.SpecFlow.UnitTestProvider;
 
 namespace Allure.SpecFlowPlugin
 {
@@ -29,13 +30,17 @@ namespace Allure.SpecFlowPlugin
         public AllureBindingInvoker(
             SpecFlowConfiguration specFlowConfiguration,
             IErrorProvider errorProvider,
-            ISynchronousBindingDelegateInvoker synchronousBindingDelegateInvoker
+            ISynchronousBindingDelegateInvoker synchronousBindingDelegateInvoker,
+            IUnitTestRuntimeProvider unitTestRuntimeProvider
         ) : base(
             specFlowConfiguration,
             errorProvider,
             synchronousBindingDelegateInvoker
         )
         {
+            AllureSpecFlowPatcher.EnsureTestPlanSupportInjected(
+                unitTestRuntimeProvider
+            );
         }
 
         public override object InvokeBinding(
@@ -376,17 +381,20 @@ namespace Allure.SpecFlowPlugin
             // to indicate the error.
             if (!featureContext.ContainsKey(PLACEHOLDER_TESTCASE_KEY))
             {
-                PluginHelper.StartTestCase(featureContext.FeatureInfo, new(
-                    "Feature hook failure placeholder",
-                    string.Format(
-                        "This is a placeholder scenario to indicate an " +
-                            "exception occured in a feature-level fixture " +
-                            "of '{0}'",
-                        featureContext.FeatureInfo.Title
-                    ),
-                    Array.Empty<string>(),
-                    new OrderedDictionary()
-                ));
+                PluginHelper.StartTestCase(
+                    featureContext.FeatureInfo,
+                    new ScenarioInfo(
+                        "Feature hook failure placeholder",
+                        string.Format(
+                            "This is a placeholder scenario to indicate an " +
+                                "exception occured in a feature-level " +
+                                "fixture of '{0}'",
+                            featureContext.FeatureInfo.Title
+                        ),
+                        Array.Empty<string>(),
+                        new OrderedDictionary()
+                    )
+                );
 
                 allure
                     .StopTestCase(makeBroken)

--- a/Allure.SpecFlowPlugin/AllureBindingInvoker.cs
+++ b/Allure.SpecFlowPlugin/AllureBindingInvoker.cs
@@ -73,13 +73,28 @@ namespace Allure.SpecFlowPlugin
             ITestTracer testTracer,
             HookBinding hook
         ) =>
-            IsAllureHook(hook) ? this.InvokeAllureBinding(
+            IsAllureHook(hook) ? this.InvokeAllureHookBinding(
                 binding,
                 contextManager,
                 arguments,
                 testTracer,
                 hook
-            ) : hook.HookType switch
+            ) : this.MakeFixtureFromFeatureOrScenarioHook(
+                binding,
+                contextManager,
+                arguments,
+                testTracer,
+                hook
+            );
+
+        (object, TimeSpan) MakeFixtureFromFeatureOrScenarioHook(
+            IBinding binding,
+            IContextManager contextManager,
+            object[] arguments,
+            ITestTracer testTracer,
+            HookBinding hook
+        ) =>
+            hook.HookType switch
             {
                 HookType.BeforeFeature =>
                     this.MakeFixtureFromBeforeFeatureHook(
@@ -300,7 +315,7 @@ namespace Allure.SpecFlowPlugin
             return result;
         }
 
-        (object, TimeSpan) InvokeAllureBinding(
+        (object, TimeSpan) InvokeAllureHookBinding(
             IBinding binding,
             IContextManager contextManager,
             object[] arguments,

--- a/Allure.SpecFlowPlugin/README.md
+++ b/Allure.SpecFlowPlugin/README.md
@@ -16,10 +16,12 @@ nuget package according to your Specflow version.
 
 For Specflow 3 please add or update the following section in your specflow.json:
 
- ```                  
-"stepAssemblies": [
-  { "assembly": "Allure.SpecFlowPlugin" }
-]
+```json      
+{
+  "stepAssemblies": [
+    { "assembly": "Allure.SpecFlowPlugin" }
+  ]
+}
 ```
 
 The plugin uses allureConfig.json extended with custom sections that are

--- a/Allure.SpecFlowPlugin/README.md
+++ b/Allure.SpecFlowPlugin/README.md
@@ -1,24 +1,52 @@
 ## SpecFlow Adapter  [![](http://img.shields.io/nuget/vpre/Allure.SpecFlow.svg?style=flat)](https://www.nuget.org/packages/Allure.SpecFlow)
-Currently supports [SpecFlow](http://specflow.org/) v2.1 - 3.1.*
 
-See [Allure report](https://allure-secondary.z23.web.core.windows.net/) generated from https://github.com/allure-framework/allure-csharp/tree/main/Allure.Features
+Currently supports [SpecFlow](http://specflow.org/) v2.1 - 3.9.*
+
+See [Allure report](https://allure-secondary.z23.web.core.windows.net/)
+generated from https://github.com/allure-framework/allure-csharp/tree/main/Allure.Features
 
 Please use corresponding NuGet package version.
+
 ### Installation
 
-Install  [Allure.SpecFlow](https://www.nuget.org/packages/Allure.SpecFlow) nuget package according to your Specflow version.
+Install  [Allure.SpecFlow](https://www.nuget.org/packages/Allure.SpecFlow)
+nuget package according to your Specflow version.
+
 ### Configuration
+
 For Specflow 3 please add or update the following section in your specflow.json:
+
  ```                  
 "stepAssemblies": [
   { "assembly": "Allure.SpecFlowPlugin" }
 ]
 ```
-The plugin uses Allure.Commons json configuration extended with custom sections.
-### Custom host name
-In case if you want to customize host name which is displayed in Allure Timeline section, please configure `allure.title` property in json configuraion file.
+
+The plugin uses allureConfig.json extended with custom sections that are
+described below.
+
+#### Custom host name
+
+In case if you want to customize host name which is displayed in Allure Timeline
+section, please configure `allure.title` property in json configuraion file.
+
+```json
+{
+    "allure": {
+        "title": "My title"
+    }
+}
+```
+
 #### If you use NUnit
-Default value for allure.directory in allureConfig.json is "allure-results", default working directory in NUnit 3.* is the working directory of console runner. If you don't want to place allure results into NUnit default working folder please either set absolute path in allure.config or set working directory for NUnit in your test setup, e.g.:
+
+The default value for allure.directory in allureConfig.json is "allure-results".
+The default working directory in NUnit 3.* depends on what runner you use.
+
+If you don't want to place allure results into NUnit default working folder
+please either set absolute path in allure.config or set working directory for
+NUnit in your test setup, e.g.:
+
 ``` csharp
 [OneTimeSetUp]
 public void Init()
@@ -26,13 +54,21 @@ public void Init()
    Environment.CurrentDirectory = Path.GetDirectoryName(GetType().Assembly.Location);
 }
 ```
+
 ### Usage
-Just run your SpecFlow scenarios and find `allure-results` folder ready to generate Allure report.
+
+Just run your SpecFlow scenarios and find the `allure-results` folder ready to
+generate Allure report.
 
 ### Features
+
 #### Grouping
-You can structure your scenarios in 3 Allure hierarchies using feature and scenario tags.
-Please read [report structure](https://docs.qameta.io/allure/latest/#_report_structure) Allure documentation section for additional details. Hierarchies consist of the following levels:
+
+You can structure your scenarios in 3 Allure hierarchies using feature and
+scenario tags.
+Please read [report structure](https://docs.qameta.io/allure/latest/#_report_structure)
+Allure documentation section for additional details. Hierarchies consist of
+the following levels:
 
 **Suites**
 * Parent Suite
@@ -49,16 +85,22 @@ Please read [report structure](https://docs.qameta.io/allure/latest/#_report_str
 * * Class
 * * * Method
 
-The plugin uses `allure:grouping` configuration section to parse tags with the regular expression. If the expression contains the group, it will be used as hierarchy level name otherwise entire match will be used. E.g:
+The plugin uses `allure:grouping` configuration section to parse tags with the
+regular expression. If the expression contains the group, it will be used as
+hierarchy level name otherwise entire match will be used. E.g:
 
 `^mytag.*` : any tags starting with `@mytag` will be used for grouping.
 
-`^type:(ui|api)` : `@ui` or `@api` tags from regex pattern will be used for grouping.
+`^type:(ui|api)` : `@ui` or `@api` tags from regex pattern will be used for
+grouping.
 
-Check this [config example](https://github.com/allure-framework/allure-csharp/blob/main/Tests.SpecRun/allureConfig.json) as a starting point.
+Check this [config example](https://github.com/allure-framework/allure-csharp/blob/main/Tests.SpecRun/allureConfig.json)
+as a starting point.
 
 #### Links
-You can add links to your scenarios using tags. Tag and link patterns can be configured in `allureConfig.json`
+You can add links to your scenarios using tags. Tag and link patterns can be
+configured in `allureConfig.json`
+
 ``` json
 {
   "allure": {
@@ -76,60 +118,85 @@ You can add links to your scenarios using tags. Tag and link patterns can be con
   }
 }
 ```
+
 The following scenario
+
 ``` cucumber
 @123456 @tms:42 @link:http://example.org 
 Scenario: I do like click on links in Allure report 
 ```
-will have three links in Allure report:
-[123456](https://myissuetracker.org/123456), [42](https://mytestmanagementsystem.org?test=tms-42) and http://example.org.
 
-In case there are links, which are generated during tests, then they can be added in code via AllureLifecycle:
+will have three links in Allure report:
+[123456](https://myissuetracker.org/123456),
+[42](https://mytestmanagementsystem.org?test=tms-42) and http://example.org.
+
+Links generated dynamically during the tests can be added in code via
+AllureLifecycle. The next example adds the [Example link](http://example.com)
+link at runtime:
+
 ``` c#
-AllureLifecycle.UpdateTestCase(testResult.uuid, tc =>
-            {
-                tc.links.Add(new Link()
-                {
-                    name = "Example link",
-                    url = "http://example.com"
-                });
-            });
+AllureLifecycle.Instance.UpdateTestCase(tc =>
+{
+    tc.links.Add(new Link()
+    {
+        name = "Example link",
+        url = "http://example.com"
+    });
+});
 ```
-This will show for scenario link with Text: Example link; and url: "http://example.com".
 
 #### Severity
-You can add Severity for your scenarios using tags. It can be configured in `allureConfig.json`
+You can add Severity for your scenarios using tags. It can be configured in
+`allureConfig.json`:
+
 ``` json
  "labels": {
       "severity": "^(normal|blocker|critical|minor|trivial)"
     },
 ```
+
 The following scenario
+
 ``` cucumber
 @critical
 Scenario: ....
 ```
-will set current scenario severity in Allure report as Blocker
+
+sets the current scenario's severity in Allure report as Blocker.
 
 #### Label
-You can add Label for your scenarios using tags. It can be configured in `allureConfig.json`
+
+You can add allure labels for your scenarios using tags. It can be configured
+in `allureConfig.json`:
+
 ``` json
  "labels": {
       "label": "^label:([\\w]+):(.+)"
     },
 ```
+
 The following scenario
+
 ``` cucumber
-@label:layer:e2e: @label:as_id:123
+@label:layer:e2e: @label:allure_id:123
 Scenario: ....
 ```
-will set current scenario Layer as e2e and Id as 123 in Allure report
+
+sets the current scenario's layer as e2e and Id as 123 in Allure report
 
 #### Tables conversion
-Table arguments in SpecFlow steps can be converted either to step csv-attacments or step parameters in the Allure report. The conversion is configurable in `specflow:stepArguments` config section.
-With `specflow:stepArguments:convertToParameters` set to `true` the following table arguments will be represented as parameters:
+
+Table arguments in SpecFlow steps can be converted either to step
+csv-attacments or step parameters in the Allure report. The conversion is
+configurable in `specflow:stepArguments` config section.
+
+With `specflow:stepArguments:convertToParameters` set to `true` the following
+table arguments will be represented as parameters:
+
 * one row tables
-* two column tables with the headers matching both `specflow:stepArguments:paramNameRegex` and `specflow:stepArguments:paramValueRegex` regular expressions.
+* two column tables with the headers matching both
+  `specflow:stepArguments:paramNameRegex` and
+  `specflow:stepArguments:paramValueRegex` regular expressions.
 
 <table>
 <th>SpecFlow</th>
@@ -149,9 +216,11 @@ With `specflow:stepArguments:convertToParameters` set to `true` the following ta
 </table>
 
 #### Attachments
+
 You can add attachments to an Allure report from your step bindings:
+
 ```csharp
-using Allure.Commons;
+using Allure.Net.Commons;
 ...
 AllureLifecycle.Instance.AddAttachment(path, "Attachment Title");
 // or

--- a/Allure.SpecFlowPlugin/SelectiveRun/AllureSpecFlowPatcher.cs
+++ b/Allure.SpecFlowPlugin/SelectiveRun/AllureSpecFlowPatcher.cs
@@ -1,0 +1,119 @@
+﻿using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using TechTalk.SpecFlow;
+using TechTalk.SpecFlow.UnitTestProvider;
+
+namespace Allure.SpecFlowPlugin.SelectiveRun
+{
+    static class AllureSpecFlowPatcher
+    {
+        const string ALLURE_ID = "io.qameta.allure.xunit";
+        static bool isTestPlanSupportInjected= false;
+
+        internal static void EnsureTestPlanSupportInjected(
+            IUnitTestRuntimeProvider unitTestRuntimeProvider
+        )
+        {
+            if (isTestPlanSupportInjected)
+            {
+                return;
+            }
+
+            InjectTestPlanSupport(unitTestRuntimeProvider);
+            isTestPlanSupportInjected = true;
+        }
+
+        static void InjectTestPlanSupport(
+            IUnitTestRuntimeProvider unitTestRuntimeProvider
+        )
+        {
+            var patcher = new Harmony(ALLURE_ID);
+            InjectTestPlanCheckToTestRunner(patcher);
+            AdjustIgnoredScenarioMessage(patcher, unitTestRuntimeProvider);
+        }
+
+        static void InjectTestPlanCheckToTestRunner(Harmony patcher) =>
+            PatchRunnerFactories(
+                patcher,
+                (
+                    from m in GetPotentialRunnerFactoryMethods()
+                    where IsRunnerFactoryCandidate(m)
+                    select m
+                )
+            );
+
+        static void AdjustIgnoredScenarioMessage(
+            Harmony patcher,
+            IUnitTestRuntimeProvider unitTestRuntimeProvider
+        )
+        {
+            var testIgnoreMethod = unitTestRuntimeProvider.GetType().GetMethod(
+                nameof(IUnitTestRuntimeProvider.TestIgnore),
+                new[] { typeof(string) }
+            );
+            if (testIgnoreMethod is not null)
+            {
+                patcher.Patch(
+                    testIgnoreMethod,
+                    prefix: new HarmonyMethod(
+                        typeof(AllureSpecFlowPatcher),
+                        nameof(ChangeMessageForTestPlanDisabledScenario)
+                    )
+                );
+            }
+        }
+
+        static void PatchRunnerFactories(
+            Harmony patcher,
+            IEnumerable<MethodInfo> factoryCandidates
+        )
+        {
+            foreach (var factoryCandidate in factoryCandidates)
+            {
+                PatchRunnerFactory(patcher, factoryCandidate);
+            }
+        }
+
+        static void PatchRunnerFactory(
+            Harmony patcher,
+            MethodInfo factoryCandidate
+        )
+        {
+            patcher.Patch(
+                factoryCandidate,
+                postfix: new HarmonyMethod(
+                    typeof(AllureSpecFlowPatcher),
+                    nameof(WrapTestRunnerWithTestPlanSupport)
+                )
+            );
+        }
+
+        static bool IsRunnerFactoryCandidate(MethodInfo method) =>
+            method.ReturnType == typeof(ITestRunner)
+                && method.GetParameters().All(p => p.IsOptional);
+
+        static IEnumerable<MethodInfo> GetPotentialRunnerFactoryMethods() =>
+            typeof(TestRunnerManager).GetMethods(
+                BindingFlags.Static | BindingFlags.Public
+            );
+
+        static ITestRunner WrapTestRunnerWithTestPlanSupport(
+            ITestRunner __result
+        )
+        {
+            return new SelectiveRunTestRunner(__result);
+        }
+
+        static void ChangeMessageForTestPlanDisabledScenario(
+            ref string __0
+        )
+        {
+            if (!SelectiveRunTestRunner.CurrentRunner.IsCurrentScenarioSelected)
+            {
+                __0 = "Deselected by the testplan.";
+            }
+        }
+    }
+}

--- a/Allure.SpecFlowPlugin/SelectiveRun/SelectiveRunTestRunner.cs
+++ b/Allure.SpecFlowPlugin/SelectiveRun/SelectiveRunTestRunner.cs
@@ -1,0 +1,202 @@
+﻿using Allure.Net.Commons;
+using Allure.Net.Commons.TestPlan;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using TechTalk.SpecFlow;
+using TechTalk.SpecFlow.UnitTestProvider;
+
+namespace Allure.SpecFlowPlugin.SelectiveRun
+{
+    internal class SelectiveRunTestRunner : ITestRunner
+    {
+        const string TESTPLAN_DESELECTION_CACHE_KEY
+            = "DESELECTED_BY_ALLURE_TESTPLAN";
+
+        static AllureTestPlan TestPlan
+        {
+            get => AllureLifecycle.Instance.TestPlan;
+        }
+
+        static readonly AsyncLocal<SelectiveRunTestRunner> asyncLocalRunner
+            = new();
+
+        internal static SelectiveRunTestRunner CurrentRunner
+        {
+            get => asyncLocalRunner.Value;
+            set => asyncLocalRunner.Value = value;
+        }
+
+        readonly ITestRunner underlyingRunner;
+
+        public SelectiveRunTestRunner(ITestRunner underlyingRunner)
+        {
+            this.underlyingRunner = underlyingRunner;
+        }
+
+        public int ThreadId => this.underlyingRunner.ThreadId;
+
+        public FeatureContext FeatureContext =>
+            this.underlyingRunner.FeatureContext;
+
+        public ScenarioContext ScenarioContext =>
+            this.underlyingRunner.ScenarioContext;
+
+        public void CollectScenarioErrors() =>
+            this.underlyingRunner.CollectScenarioErrors();
+
+        public void InitializeTestRunner(int threadId) =>
+            this.underlyingRunner.InitializeTestRunner(threadId);
+
+        public void OnFeatureEnd() =>
+            this.underlyingRunner.OnFeatureEnd();
+
+        public void OnFeatureStart(FeatureInfo featureInfo) =>
+            this.underlyingRunner.OnFeatureStart(featureInfo);
+
+        public void OnScenarioEnd() =>
+            this.underlyingRunner.OnScenarioEnd();
+
+        static HashSet<IUnitTestRuntimeProvider> runtimes = new();
+
+        public void OnScenarioInitialize(ScenarioInfo scenarioInfo)
+        {
+            this.underlyingRunner.OnScenarioInitialize(scenarioInfo);
+            this.ApplyTestPlanToCurrentScenario();
+            CurrentRunner = this;
+            var runtime = (IUnitTestRuntimeProvider)this.ScenarioContext.GetBindingInstance(
+                typeof(IUnitTestRuntimeProvider)
+            );
+            runtimes.Add(runtime);
+        }
+
+        public void OnScenarioStart()
+        {
+            if (this.IsCurrentScenarioSelected)
+            {
+                this.underlyingRunner.OnScenarioStart();
+            }
+            else
+            {
+                this.SkipScenario();
+            }
+        }
+
+        public void OnTestRunEnd() =>
+            this.underlyingRunner.OnTestRunEnd();
+
+        public void OnTestRunStart() =>
+            this.underlyingRunner.OnTestRunStart();
+
+        public void Pending() =>
+            this.underlyingRunner.Pending();
+
+        public void SkipScenario() =>
+            this.underlyingRunner.SkipScenario();
+
+        public void And(
+            string text,
+            string multilineTextArg,
+            Table tableArg,
+            string? keyword = null
+        ) =>
+            this.CallStepOfSelectedScenario(
+                this.underlyingRunner.And,
+                text,
+                multilineTextArg,
+                tableArg,
+                keyword
+            );
+
+        public void But(
+            string text,
+            string multilineTextArg,
+            Table tableArg,
+            string? keyword = null
+        ) =>
+            this.CallStepOfSelectedScenario(
+                this.underlyingRunner.But,
+                text,
+                multilineTextArg,
+                tableArg,
+                keyword
+            );
+
+        public void Given(
+            string text,
+            string multilineTextArg,
+            Table tableArg,
+            string? keyword = null
+        ) =>
+            this.CallStepOfSelectedScenario(
+                this.underlyingRunner.Given,
+                text,
+                multilineTextArg,
+                tableArg,
+                keyword
+            );
+
+        public void Then(
+            string text,
+            string multilineTextArg,
+            Table tableArg,
+            string? keyword = null
+        ) =>
+            this.CallStepOfSelectedScenario(
+                this.underlyingRunner.Then,
+                text,
+                multilineTextArg,
+                tableArg,
+                keyword
+            );
+
+        public void When(
+            string text,
+            string multilineTextArg,
+            Table tableArg,
+            string? keyword = null
+        ) =>
+            this.CallStepOfSelectedScenario(
+                this.underlyingRunner.When,
+                text,
+                multilineTextArg,
+                tableArg,
+                keyword
+            );
+
+        internal bool IsCurrentScenarioSelected
+        {
+            get => !this.ScenarioContext.ContainsKey(
+                TESTPLAN_DESELECTION_CACHE_KEY)
+            ;
+        }
+
+        void ApplyTestPlanToCurrentScenario()
+        {
+            var (labels, _) = PluginHelper.GetOrParseLabelsAndLinks(
+                this.FeatureContext.FeatureInfo,
+                this.ScenarioContext
+            );
+            var fullName = this.ScenarioContext.ScenarioInfo.Title;
+            var allureId = AllureTestPlan.GetAllureId(labels);
+            if (!TestPlan.IsSelected(fullName, allureId))
+            {
+                this.ScenarioContext.Set(true, TESTPLAN_DESELECTION_CACHE_KEY);
+            }
+        }
+
+        void CallStepOfSelectedScenario(
+            Action<string, string, Table, string?> stepFn,
+            string text,
+            string multilineTextArg,
+            Table tableArg,
+            string? keyword
+        )
+        {
+            if (this.IsCurrentScenarioSelected)
+            {
+                stepFn(text, multilineTextArg, tableArg, keyword);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Context
This PR is a direct continuation of #390. It adds implementation of selective run to allure-specflow.

### Implementation details
There is no consistent API to skip a SpecFlow scenario. `TechTalk.SpecFlow.UnitTestProvider.IUnitTestRuntimeProvider.TestIgnore` works only inside a step definition. So, we fall back to runtime patching again.

This time we patch `TechTalk.SpecFlow.TestRunnerManager`'s static factory methods. We don't bind to a specific method because its name might change at some point (it's named `GetTestRunner` in GA versions, but was renamed to `GetTestRunnerForAssembly` in the repo, see [[1]]). What we patch instead is any static method that:

  - Returns ITestRunner
  - Can be called with no arguments (either all arguments are optional, or it has no arguments at all)

The patched version returns a wrapper over the original test runner. The wrapper applies a test plan check and either directly calls the original runner or skips the scenario.
 
Additionally, we patch IUnitTestRuntimeProvider.TestIgnore to enhance the skip message (otherwise, a misleading message is shown that the scenario was skipped because of the `@Ignore` tag).

### Other changes
The PR also contains the following changes:

#### Explicit targeting of net462 is removed
`net462` was removed from target frameworks. We already target netstandard2.0 and net462 implements it. Besides, targeting net462 causes troubles with Harmony because a resolved version of MonoMod.Backports (a transitive dependency of Harmony) contains a duplicated definition of ValueTuple that produces compilation errors if value tuples are used in the source code.

#### Update SpecFlow version used to test allure-specflow to 3.9.52
Allure-specflow now is tested using SpecFlow v3.9.52. We can't use a newer version unless we drop SpecFlow.SharedSteps from the test suite (SpecFlow.SharedSteps isn't supported by SpecFlow version 3.9.58 or higher because of [this commit](https://github.com/SpecFlowOSS/SpecFlow/commit/920212ae5fb317d5db4b52f85431f7a8c84e4dbd) that removes the `virtual` specified from methods of a generated scenario class).

### Known issue
Again, as for allure-xunit, there might be a small chance that selective run will not work if the target method of `TechTalk.SpecFlow.TestRunnerManager` gets inlined by the CLR. A workaround is to switch to the debug configuration. This is tracked by #369.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
[1]: https://github.com/SpecFlowOSS/SpecFlow/blob/8e0e7d4cecacc0dd3267f12c34477c30c84a2c37/TechTalk.SpecFlow/TestRunnerManager.cs#L273