### PR TITLE
Fix regression: non-working lambda-steps and lambda-fixtures API

### DIFF
--- a/Allure.Net.Commons.Tests/StepFunctionTests.cs
+++ b/Allure.Net.Commons.Tests/StepFunctionTests.cs
@@ -1,0 +1,378 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Allure.Net.Commons.Steps;
+using NUnit.Framework;
+
+namespace Allure.Net.Commons.Tests;
+
+class StepAndFixtureFunctionTests
+{
+    AllureLifecycle lifecycle;
+
+    static readonly Action errorAction = () => throw new Exception();
+    static readonly Func<int> errorFunc = () => throw new Exception();
+    static readonly Func<Task> asyncErrorAction
+        = async () => await Task.FromException(new Exception());
+    static readonly Func<Task<int>> asyncErrorFunc
+        = async () => await Task.FromException<int>(new Exception());
+
+    [SetUp]
+    public void SetUp()
+    {
+        this.lifecycle = new AllureLifecycle();
+        CoreStepsHelper.CurrentLifecycle = this.lifecycle;
+    }
+
+    [Test]
+    public void ActionCanBeConvertedToBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        CoreStepsHelper.Before("My fixture", () => { });
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void ActionCanBeConvertedToFailedBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            () => CoreStepsHelper.Before("My fixture", errorAction),
+            Throws.Exception
+        );
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public void FuncCanBeConvertedToBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        var result = CoreStepsHelper.Before("My fixture", () => 0);
+
+        Assert.That(result, Is.Zero);
+        this.AssertBeforeFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void FuncCanBeConvertedToFailedBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            () => CoreStepsHelper.Before("My fixture", errorFunc),
+            Throws.Exception
+        );
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public async Task AsyncActionCanBeConvertedToBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        await CoreStepsHelper.Before(
+            "My fixture",
+            async () => await Task.CompletedTask
+        );
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void AsyncActionCanBeConvertedToFailedBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            async () => await CoreStepsHelper.Before(
+                "My fixture",
+                asyncErrorAction
+            ),
+            Throws.Exception
+        );
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public async Task AsyncFuncCanBeConvertedToBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        await CoreStepsHelper.Before(
+            "My fixture",
+            async () => await Task.FromResult(0)
+        );
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void AsyncFuncCanBeConvertedToFailedBeforeFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            async () => await CoreStepsHelper.Before(
+                "My fixture",
+                asyncErrorFunc
+            ),
+            Throws.Exception
+        );
+
+        this.AssertBeforeFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public void ActionCanBeConvertedToAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        CoreStepsHelper.After("My fixture", () => { });
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void ActionCanBeConvertedToFailedAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            () => CoreStepsHelper.After("My fixture", errorAction),
+            Throws.Exception
+        );
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public void FuncCanBeConvertedToAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        var result = CoreStepsHelper.After("My fixture", () => 0);
+
+        Assert.That(result, Is.Zero);
+        this.AssertAfterFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void FuncCanBeConvertedToFailedAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            () => CoreStepsHelper.After("My fixture", errorFunc),
+            Throws.Exception
+        );
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public async Task AsyncActionCanBeConvertedToAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        await CoreStepsHelper.After(
+            "My fixture",
+            async () => await Task.CompletedTask
+        );
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void AsyncActionCanBeConvertedToFailedAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            async () => await CoreStepsHelper.After(
+                "My fixture",
+                asyncErrorAction
+            ),
+            Throws.Exception
+        );
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public async Task AsyncFuncCanBeConvertedToAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        await CoreStepsHelper.After(
+            "My fixture",
+            async () => await Task.FromResult(0)
+        );
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.passed);
+    }
+
+    [Test]
+    public void AsyncFuncCanBeConvertedToFailedAfterFixture()
+    {
+        this.lifecycle.StartTestContainer(new() { uuid = "uuid" });
+
+        Assert.That(
+            async () => await CoreStepsHelper.After(
+                "My fixture",
+                asyncErrorFunc
+            ),
+            Throws.Exception
+        );
+
+        this.AssertAfterFixtureCompleted("My fixture", Status.failed);
+    }
+
+    [Test]
+    public void StepWithNoActionCanBeCreated()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        CoreStepsHelper.Step("My step");
+
+        this.AssertStepCompleted("My step", Status.passed);
+    }
+
+    [Test]
+    public void ActionCanBeConvertedToStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        CoreStepsHelper.Step("My step", () => { });
+
+        this.AssertStepCompleted("My step", Status.passed);
+    }
+
+    [Test]
+    public void ActionCanBeConvertedToFailedStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        Assert.That(
+            () => CoreStepsHelper.Step("My step", errorAction),
+            Throws.Exception
+        );
+
+        this.AssertStepCompleted("My step", Status.failed);
+    }
+
+    [Test]
+    public void FuncCanBeConvertedToStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        var result = CoreStepsHelper.Step("My step", () => 0);
+
+        Assert.That(result, Is.Zero);
+        this.AssertStepCompleted("My step", Status.passed);
+    }
+
+    [Test]
+    public void FuncCanBeConvertedToFailedStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        Assert.That(
+            () => CoreStepsHelper.Step("My step", errorFunc),
+            Throws.Exception
+        );
+
+        this.AssertStepCompleted("My step", Status.failed);
+    }
+
+    [Test]
+    public async Task AsyncActionCanBeConvertedToStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        await CoreStepsHelper.Step(
+            "My step",
+            async () => await Task.CompletedTask
+        );
+
+        this.AssertStepCompleted("My step", Status.passed);
+    }
+
+    [Test]
+    public void AsyncActionCanBeConvertedToFailedStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        Assert.That(
+            async () => await CoreStepsHelper.Step("My step", asyncErrorAction),
+            Throws.Exception
+        );
+
+        this.AssertStepCompleted("My step", Status.failed);
+    }
+
+    [Test]
+    public async Task AsyncFuncCanBeConvertedToStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        await CoreStepsHelper.Step(
+            "My step",
+            async () => await Task.FromResult(0)
+        );
+
+        this.AssertStepCompleted("My step", Status.passed);
+    }
+
+    [Test]
+    public void AsyncFuncCanBeConvertedToFailedStep()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "uuid" });
+
+        Assert.That(
+            async () => await CoreStepsHelper.Step("My step", asyncErrorFunc),
+            Throws.Exception
+        );
+
+        this.AssertStepCompleted("My step", Status.failed);
+    }
+
+    void AssertBeforeFixtureCompleted(string name, Status status) =>
+        this.AssertFixtureCompleted(tc => tc.befores, name, status);
+
+    void AssertAfterFixtureCompleted(string name, Status status) =>
+        this.AssertFixtureCompleted(tc => tc.afters, name, status);
+
+    void AssertFixtureCompleted(
+        Func<TestResultContainer, List<FixtureResult>> getFixtures,
+        string name,
+        Status status
+    )
+    {
+        Assert.That(this.lifecycle.Context.HasFixture, Is.False);
+        Assert.That(this.lifecycle.Context.HasContainer);
+        var fixtures = getFixtures(this.lifecycle.Context.CurrentContainer);
+        Assert.That(fixtures, Has.Count.EqualTo(1));
+        var fixture = fixtures.First();
+        Assert.That(fixture.name, Is.EqualTo(name));
+        Assert.That(fixture.status, Is.EqualTo(status));
+    }
+
+    void AssertStepCompleted(string name, Status status)
+    {
+        Assert.That(this.lifecycle.Context.HasStep, Is.False);
+        Assert.That(this.lifecycle.Context.HasTest);
+        var steps = this.lifecycle.Context.CurrentTest.steps;
+        Assert.That(steps, Has.Count.EqualTo(1));
+        var fixture = steps.First();
+        Assert.That(fixture.name, Is.EqualTo(name));
+        Assert.That(fixture.status, Is.EqualTo(status));
+    }
+}

--- a/Allure.Net.Commons/Steps/CoreStepsHelper.cs
+++ b/Allure.Net.Commons/Steps/CoreStepsHelper.cs
@@ -9,27 +9,77 @@ namespace Allure.Net.Commons.Steps;
 
 public class CoreStepsHelper
 {
+    static AllureLifecycle? lifecycleInstance;
+
+    internal static AllureLifecycle CurrentLifecycle
+    {
+        get => lifecycleInstance ?? AllureLifecycle.Instance;
+        set => lifecycleInstance = value;
+    }
+
     public static IStepLogger? StepLogger { get; set; }
 
     #region Fixtures
 
     public static void StartBeforeFixture(string name)
     {
-        AllureLifecycle.Instance.StartBeforeFixture(new() { name = name });
+        CurrentLifecycle.StartBeforeFixture(new() { name = name });
         StepLogger?.BeforeStarted?.Log(name);
     }
 
     public static void StartAfterFixture(string name)
     {
-        AllureLifecycle.Instance.StartAfterFixture(new() { name = name });
+        CurrentLifecycle.StartAfterFixture(new() { name = name });
         StepLogger?.AfterStarted?.Log(name);
     }
 
+    public static void PassFixture() => CurrentLifecycle.StopFixture(
+        result =>
+        {
+            result.status = Status.passed;
+            StepLogger?.StepPassed?.Log(result.name);
+        }
+    );
+
+    public static void PassFixture(Action<FixtureResult> updateResults)
+    {
+        CurrentLifecycle.UpdateFixture(updateResults);
+        PassFixture();
+    }
+
+    public static void FailFixture() => CurrentLifecycle.StopFixture(
+        result =>
+        {
+            result.status = Status.failed;
+            StepLogger?.StepFailed?.Log(result.name);
+        }
+    );
+
+    public static void FailFixture(Action<FixtureResult> updateResults)
+    {
+        CurrentLifecycle.UpdateFixture(updateResults);
+        FailFixture();
+    }
+
+    public static void BrokeFixture() => CurrentLifecycle.StopFixture(
+        result =>
+        {
+            result.status = Status.broken;
+            StepLogger?.StepBroken?.Log(result.name);
+        }
+    );
+
+    public static void BrokeFixture(Action<FixtureResult> updateResults)
+    {
+        CurrentLifecycle.UpdateFixture(updateResults);
+        BrokeFixture();
+    }
+
     public static void StopFixture(Action<FixtureResult> updateResults) =>
-        AllureLifecycle.Instance.StopFixture(updateResults);
+        CurrentLifecycle.StopFixture(updateResults);
 
     public static void StopFixture() =>
-        AllureLifecycle.Instance.StopFixture();
+        CurrentLifecycle.StopFixture();
 
     #endregion
 
@@ -37,17 +87,17 @@ public class CoreStepsHelper
 
     public static void StartStep(string name)
     {
-        AllureLifecycle.Instance.StartStep(new() { name = name });
+        CurrentLifecycle.StartStep(new() { name = name });
         StepLogger?.StepStarted?.Log(name);
     }
 
     public static void StartStep(string name, Action<StepResult> updateResults)
     {
         StartStep(name);
-        AllureLifecycle.Instance.UpdateStep(updateResults);
+        CurrentLifecycle.UpdateStep(updateResults);
     }
 
-    public static void PassStep() => AllureLifecycle.Instance.StopStep(
+    public static void PassStep() => CurrentLifecycle.StopStep(
         result =>
         {
             result.status = Status.passed;
@@ -57,11 +107,11 @@ public class CoreStepsHelper
 
     public static void PassStep(Action<StepResult> updateResults)
     {
-        AllureLifecycle.Instance.UpdateStep(updateResults);
+        CurrentLifecycle.UpdateStep(updateResults);
         PassStep();
     }
 
-    public static void FailStep() => AllureLifecycle.Instance.StopStep(
+    public static void FailStep() => CurrentLifecycle.StopStep(
         result =>
         {
             result.status = Status.failed;
@@ -71,11 +121,11 @@ public class CoreStepsHelper
 
     public static void FailStep(Action<StepResult> updateResults)
     {
-        AllureLifecycle.Instance.UpdateStep(updateResults);
+        CurrentLifecycle.UpdateStep(updateResults);
         FailStep();
     }
 
-    public static void BrokeStep() => AllureLifecycle.Instance.StopStep(
+    public static void BrokeStep() => CurrentLifecycle.StopStep(
         result =>
         {
             result.status = Status.broken;
@@ -85,7 +135,7 @@ public class CoreStepsHelper
 
     public static void BrokeStep(Action<StepResult> updateResults)
     {
-        AllureLifecycle.Instance.UpdateStep(updateResults);
+        CurrentLifecycle.UpdateStep(updateResults);
         BrokeStep();
     }
 
@@ -94,136 +144,164 @@ public class CoreStepsHelper
     #region Misc
 
     public static void UpdateTestResult(Action<TestResult> update) =>
-        AllureLifecycle.Instance.UpdateTestCase(update);
+        CurrentLifecycle.UpdateTestCase(update);
 
     #endregion
 
-    public static Task<T> Step<T>(string name, Func<Task<T>> action)
-    {
-        StartStep(name);
-        return Execute(action);
-    }
+    public static async Task<T> Step<T>(string name, Func<Task<T>> action) =>
+        await ExecuteStep(name, action);
 
-    public static T Step<T>(string name, Func<T> action)
-    {
-        StartStep(name);
-        return Execute(name, action);
-    }
+    public static T Step<T>(string name, Func<T> action) =>
+        ExecuteStep(name, action);
 
     public static void Step(string name, Action action)
     {
-        Step(name, (Func<object?>)(() =>
+        ExecuteStep(name, () =>
         {
             action();
-            return null;
-        }));
+            return null as object;
+        });
     }
 
-    public static Task Step(string name, Func<Task> action)
-    {
-        return Step(name, async () =>
+    public static async Task Step(string name, Func<Task> action) =>
+        await ExecuteStep(name, async () =>
         {
             await action();
             return Task.FromResult<object?>(null);
         });
-    }
 
-    public static void Step(string name)
-    {
+    public static void Step(string name) =>
         Step(name, () => { });
-    }
 
-    public static Task<T> Before<T>(string name, Func<Task<T>> action)
-    {
-        StartBeforeFixture(name);
-        return Execute(action);
-    }
+    public static async Task<T> Before<T>(string name, Func<Task<T>> action) =>
+        await ExecuteFixture(name, StartBeforeFixture, action);
 
-    public static T Before<T>(string name, Func<T> action)
-    {
-        StartBeforeFixture(name);
-        return Execute(name, action);
-    }
+    public static T Before<T>(string name, Func<T> action) =>
+        ExecuteFixture(name, StartBeforeFixture, action);
 
-    public static void Before(string name, Action action)
-    {
-        Before(name, (Func<object?>)(() =>
+    public static void Before(string name, Action action) =>
+        Before(name, () =>
         {
             action();
-            return null;
-        }));
-    }
+            return null as object;
+        });
 
-    public static Task Before(string name, Func<Task> action)
-    {
-        return Before(name, async () =>
+    public static async Task Before(string name, Func<Task> action) =>
+        await ExecuteFixture(name, StartBeforeFixture, async () =>
         {
             await action();
             return Task.FromResult<object?>(null);
         });
-    }
 
-    public static Task<T> After<T>(string name, Func<Task<T>> action)
-    {
-        StartAfterFixture(name);
-        return Execute(action);
-    }
+    public static async Task<T> After<T>(string name, Func<Task<T>> action) =>
+        await ExecuteFixture(name, StartAfterFixture, action);
 
-    public static T After<T>(string name, Func<T> action)
-    {
-        StartAfterFixture(name);
-        return Execute(name, action);
-    }
+    public static T After<T>(string name, Func<T> action) =>
+        ExecuteFixture(name, StartAfterFixture, action);
 
-    public static void After(string name, Action action)
-    {
-        After(name, (Func<object?>)(() =>
+    public static void After(string name, Action action) =>
+        After(name, () =>
         {
             action();
-            return null;
-        }));
-    }
+            return null as object;
+        });
 
-    public static Task After(string name, Func<Task> action)
-    {
-        return After(name, async () =>
+    public static async Task After(string name, Func<Task> action) =>
+        await ExecuteFixture(name, StartAfterFixture, async () =>
         {
             await action();
             return Task.FromResult<object?>(null);
         });
-    }
 
-    private static async Task<T> Execute<T>(Func<Task<T>> action)
+    static T ExecuteStep<T>(string name, Func<T> action) =>
+        ExecuteAction(
+            name,
+            StartStep,
+            action,
+            PassStep,
+            FailStep
+        );
+
+    static async Task<T> ExecuteStep<T>(
+        string name,
+        Func<Task<T>> action
+    ) =>
+        await ExecuteAction(
+            () => StartStep(name),
+            action,
+            PassStep,
+            FailStep
+        );
+
+    static T ExecuteFixture<T>(
+        string name,
+        Action<string> start,
+        Func<T> action
+    ) =>
+        ExecuteAction(
+            name,
+            start,
+            action,
+            PassFixture,
+            FailFixture
+        );
+
+    static async Task<T> ExecuteFixture<T>(
+        string name,
+        Action<string> startFixture,
+        Func<Task<T>> action
+    ) =>
+        await ExecuteAction(
+            () => startFixture(name),
+            action,
+            PassFixture,
+            FailFixture
+        );
+
+    private static async Task<T> ExecuteAction<T>(
+        Action start,
+        Func<Task<T>> action,
+        Action pass,
+        Action fail
+    )
     {
         T result;
+        start();
         try
         {
             result = await action();
         }
         catch (Exception)
         {
-            FailStep();
+            fail();
             throw;
         }
 
-        PassStep();
+        pass();
         return result;
     }
 
-    private static T Execute<T>(string name, Func<T> action)
+    private static T ExecuteAction<T>(
+        string name,
+        Action<string> start,
+        Func<T> action,
+        Action pass,
+        Action fail
+    )
     {
         T result;
+        start(name);
         try
         {
             result = action();
         }
         catch (Exception e)
         {
-            FailStep();
+            fail();
             throw new StepFailedException(name, e);
         }
 
-        PassStep();
+        pass();
         return result;
     }
 
@@ -259,13 +337,13 @@ public class CoreStepsHelper
         Action<StepResult>? updateResults = null
     )
     {
-        AllureLifecycle.Instance.UpdateStep(uuid, result =>
+        CurrentLifecycle.UpdateStep(uuid, result =>
         {
             result.status = Status.passed;
             updateResults?.Invoke(result);
             StepLogger?.StepPassed?.Log(result.name);
         });
-        AllureLifecycle.Instance.StopStep(uuid);
+        CurrentLifecycle.StopStep(uuid);
     }
 
     [Obsolete(AllureLifecycle.EXPLICIT_STATE_MGMT_OBSOLETE)]
@@ -275,13 +353,13 @@ public class CoreStepsHelper
         Action<StepResult>? updateResults = null
     )
     {
-        AllureLifecycle.Instance.UpdateStep(uuid, result =>
+        CurrentLifecycle.UpdateStep(uuid, result =>
         {
             result.status = Status.failed;
             updateResults?.Invoke(result);
             StepLogger?.StepFailed?.Log(result.name);
         });
-        AllureLifecycle.Instance.StopStep(uuid);
+        CurrentLifecycle.StopStep(uuid);
     }
 
     [Obsolete(AllureLifecycle.EXPLICIT_STATE_MGMT_OBSOLETE)]
@@ -291,13 +369,13 @@ public class CoreStepsHelper
         Action<StepResult>? updateResults = null
     )
     {
-        AllureLifecycle.Instance.UpdateStep(uuid, result =>
+        CurrentLifecycle.UpdateStep(uuid, result =>
         {
             result.status = Status.broken;
             updateResults?.Invoke(result);
             StepLogger?.StepBroken?.Log(result.name);
         });
-        AllureLifecycle.Instance.StopStep(uuid);
+        CurrentLifecycle.StopStep(uuid);
     }
 
     #endregion

--- a/Allure.Net.Commons/Steps/CoreStepsHelper.cs
+++ b/Allure.Net.Commons/Steps/CoreStepsHelper.cs
@@ -148,11 +148,8 @@ public class CoreStepsHelper
 
     #endregion
 
-    public static async Task<T> Step<T>(string name, Func<Task<T>> action) =>
-        await ExecuteStep(name, action);
-
-    public static T Step<T>(string name, Func<T> action) =>
-        ExecuteStep(name, action);
+    public static void Step(string name) =>
+        Step(name, () => { });
 
     public static void Step(string name, Action action)
     {
@@ -163,21 +160,18 @@ public class CoreStepsHelper
         });
     }
 
+    public static T Step<T>(string name, Func<T> action) =>
+        ExecuteStep(name, action);
+
     public static async Task Step(string name, Func<Task> action) =>
-        await ExecuteStep(name, async () =>
+        await ExecuteStepAsync(name, async () =>
         {
             await action();
             return Task.FromResult<object?>(null);
         });
 
-    public static void Step(string name) =>
-        Step(name, () => { });
-
-    public static async Task<T> Before<T>(string name, Func<Task<T>> action) =>
-        await ExecuteFixture(name, StartBeforeFixture, action);
-
-    public static T Before<T>(string name, Func<T> action) =>
-        ExecuteFixture(name, StartBeforeFixture, action);
+    public static async Task<T> Step<T>(string name, Func<Task<T>> action) =>
+        await ExecuteStepAsync(name, action);
 
     public static void Before(string name, Action action) =>
         Before(name, () =>
@@ -186,18 +180,18 @@ public class CoreStepsHelper
             return null as object;
         });
 
+    public static T Before<T>(string name, Func<T> action) =>
+        ExecuteFixture(name, StartBeforeFixture, action);
+
     public static async Task Before(string name, Func<Task> action) =>
-        await ExecuteFixture(name, StartBeforeFixture, async () =>
+        await ExecuteFixtureAsync(name, StartBeforeFixture, async () =>
         {
             await action();
             return Task.FromResult<object?>(null);
         });
 
-    public static async Task<T> After<T>(string name, Func<Task<T>> action) =>
-        await ExecuteFixture(name, StartAfterFixture, action);
-
-    public static T After<T>(string name, Func<T> action) =>
-        ExecuteFixture(name, StartAfterFixture, action);
+    public static async Task<T> Before<T>(string name, Func<Task<T>> action) =>
+        await ExecuteFixtureAsync(name, StartBeforeFixture, action);
 
     public static void After(string name, Action action) =>
         After(name, () =>
@@ -206,12 +200,18 @@ public class CoreStepsHelper
             return null as object;
         });
 
+    public static T After<T>(string name, Func<T> action) =>
+        ExecuteFixture(name, StartAfterFixture, action);
+
     public static async Task After(string name, Func<Task> action) =>
-        await ExecuteFixture(name, StartAfterFixture, async () =>
+        await ExecuteFixtureAsync(name, StartAfterFixture, async () =>
         {
             await action();
             return Task.FromResult<object?>(null);
         });
+
+    public static async Task<T> After<T>(string name, Func<Task<T>> action) =>
+        await ExecuteFixtureAsync(name, StartAfterFixture, action);
 
     static T ExecuteStep<T>(string name, Func<T> action) =>
         ExecuteAction(
@@ -222,11 +222,11 @@ public class CoreStepsHelper
             FailStep
         );
 
-    static async Task<T> ExecuteStep<T>(
+    static async Task<T> ExecuteStepAsync<T>(
         string name,
         Func<Task<T>> action
     ) =>
-        await ExecuteAction(
+        await ExecuteActionAsync(
             () => StartStep(name),
             action,
             PassStep,
@@ -246,19 +246,19 @@ public class CoreStepsHelper
             FailFixture
         );
 
-    static async Task<T> ExecuteFixture<T>(
+    static async Task<T> ExecuteFixtureAsync<T>(
         string name,
         Action<string> startFixture,
         Func<Task<T>> action
     ) =>
-        await ExecuteAction(
+        await ExecuteActionAsync(
             () => startFixture(name),
             action,
             PassFixture,
             FailFixture
         );
 
-    private static async Task<T> ExecuteAction<T>(
+    private static async Task<T> ExecuteActionAsync<T>(
         Action start,
         Func<Task<T>> action,
         Action pass,

--- a/Allure.XUnit/AllureXunitConfiguration.cs
+++ b/Allure.XUnit/AllureXunitConfiguration.cs
@@ -1,10 +1,9 @@
-﻿using Allure.Net.Commons;
+﻿using System;
+using System.Collections.Generic;
+using Allure.Net.Commons;
 using Allure.Net.Commons.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System;
-using System.Collections.Generic;
-using System.IO;
 
 #nullable enable
 
@@ -16,9 +15,9 @@ namespace Allure.XUnit
 
         [JsonConstructor]
         protected AllureXunitConfiguration(
-            string title,
-            string directory,
-            HashSet<string> links
+            string? title,
+            string? directory,
+            HashSet<string>? links
         ) : base(title, directory, links)
         {
         }
@@ -34,8 +33,6 @@ namespace Allure.XUnit
         static AllureXunitConfiguration ParseCurrentConfig() => JObject.Parse(
             AllureLifecycle.Instance.JsonConfiguration
         )["allure"]?.ToObject<AllureXunitConfiguration>()
-            ?? throw new FileNotFoundException(
-                "allureConfig.json not found"
-            );
+            ?? new AllureXunitConfiguration(null, null, null);
     }
 }


### PR DESCRIPTION
### Context
Before #371 a fixture context and a step context were basically the same thing. `CoreStepsHelper` took advantage of this by two merits:
  1. It used the same set of methods to stop both steps and fixtures while implementing the API for lambda steps and lambda fixtures.
  2. It implemented the async lambda steps API as non-async methods (i.e., without the `async` keyword).

Due to changes introduced by #371, the following has happened:

  1. The methods to explicitly stop a step have stopped working in the context of a fixture.
  2. Because of that, the lambda-fixtures have stopped working as well.
  3. What's more important, async lambda-step API now leak the step into the context of a caller, because the restoration of the execution context by the CLR happens back to the point where the step has already been started.

### Description of changes

#### Better allure context isolation for async lambda-steps and async lambda-fixtures

The async lambda-step and the async lambda-fixture methods are now proper async functions:

```csharp
public static async Task Step(string name, Func<Task> action) =>
    ...
```

This means any changes to the allure context are now fully isolated from a caller.

#### New API for explicit fixture management
Since the fixture and the step contexts are now separated, the following list of methods was added to the API to stop a fixture explicitly:

```csharp
public static void Allure.Net.Commons.Steps.CoreStepsHelper.StopFixture();
public static void Allure.Net.Commons.Steps.CoreStepsHelper.StopFixture(System.Action<Allure.Net.Commons.FixtureResult> updateResults);
public static void Allure.Net.Commons.Steps.CoreStepsHelper.PassFixture();
public static void Allure.Net.Commons.Steps.CoreStepsHelper.PassFixture(System.Action<Allure.Net.Commons.FixtureResult> updateResults);
public static void Allure.Net.Commons.Steps.CoreStepsHelper.FailFixture();
public static void Allure.Net.Commons.Steps.CoreStepsHelper.FailFixture(System.Action<Allure.Net.Commons.FixtureResult> updateResults);
public static void Allure.Net.Commons.Steps.CoreStepsHelper.BrokeFixture();
public static void Allure.Net.Commons.Steps.CoreStepsHelper.BrokeFixture(System.Action<Allure.Net.Commons.FixtureResult> updateResults);
```

These functions are now properly used instead step-related ones to implement the lambda-fixture API.

### Other changes
The PR also contains the following change(s):

#### Unit tests for `CoreStepsHelper`

The internal static `CurrentLifecycle` property has been introduced into the `CoreStepsHelper` class to decouple it from a file system bound AllureLifecycle for testing purposes.

The PR covers lambda-step and lambda-fixture methods of `CoreStepsHelper` with tests. Other method for explicit steps/fixtures management are still not covered.

#### Default allureConfig.json for allure-xunit

If no allureConfig.json is provided for Allure.XUnit, the default one is used instead of throwing a catastrophic failure and aborting the run. This fixes #381.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2

Fixes #381 
Fixes #383 
Fixes #388 