### PR TITLE
Lower the required AspectInjector version for users back to 2.8.1 (workaround for #391)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       - name: 'Build project using dotnet'
         run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }} -p:ContinuousIntegrationBuild=true
 
+        # Lower AspectInjector requirement for users of the packages to workaround #391 (build crash on macOS arm machines)
       - name: Reduce AspectInjector requirement to 2.8.1
         run: |
             dotnet add Allure.Net.Commons package AspectInjector --version 2.8.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,11 @@ jobs:
       - name: 'Build project using dotnet'
         run: dotnet build ${{ env.SOLUTION_PATH }} --no-restore --configuration ${{ env.BUILD_CONFIGURATION }} -p:ContinuousIntegrationBuild=true
 
+      - name: Reduce AspectInjector requirement to 2.8.1
+        run: |
+            dotnet add Allure.Net.Commons package AspectInjector --version 2.8.1
+            dotnet add Allure.XUnit package AspectInjector --version 2.8.1
+
       - name: 'Pack project'
         run: dotnet pack ${{ env.SOLUTION_PATH }} --no-restore --no-build --configuration ${{ env.BUILD_CONFIGURATION }} -p:PackageOutputPath=${{ env.PACKAGE_OUTPUT_PATH }}
 

--- a/Allure.NUnit/README.md
+++ b/Allure.NUnit/README.md
@@ -4,19 +4,19 @@ NUnit adapter for Allure Framework
 [![Nuget](https://img.shields.io/nuget/v/Allure.NUnit?style=flat)](https://www.nuget.org/packages/Allure.NUnit)
 [![Nuget pre](https://img.shields.io/nuget/vpre/Allure.Nunit?style=flat)](https://www.nuget.org/packages/Allure.NUnit)
 
-![Nuget downloads](https://img.shields.io/nuget/dt/nunit.allure?label=downloads&style=flat)
+![Nuget downloads](https://img.shields.io/nuget/dt/allure.nunit?label=downloads&style=flat)
 
 
 
 ![Allure report](https://raw.githubusercontent.com/unickq/allure-nunit/master/AllureScreen.png)
 
 
-### [Code examples](https://github.com/unickq/allure-nunit/tree/master/src/allure-nunit-tests):
+### [Code examples](https://github.com/allure-framework/allure-csharp/tree/main/Allure.NUnit.Examples):
 
 ```cs
 [TestFixture(Author = "unickq", Description = "Examples")]
 [AllureNUnit]
-[AllureLink("https://github.com/unickq/allure-nunit")]
+[AllureLink("https://github.com/allure-framework/allure-csharp")]
 public class Tests
 {
     [OneTimeSetUp]
@@ -25,7 +25,6 @@ public class Tests
         AllureLifecycle.Instance.CleanupResultDirectory();
     }
 
-    //Allure.Steps required
     [AllureStep("This method is just saying hello")]
     private void SayHello()
     {
@@ -34,7 +33,7 @@ public class Tests
 
     [Test]
     [AllureTag("NUnit", "Debug")]
-    [AllureIssue("GitHub#1", "https://github.com/unickq/allure-nunit")]
+    [AllureIssue("GitHub#1", "https://github.com/allure-framework/allure-csharp")]
     [AllureSeverity(SeverityLevel.critical)]
     [AllureFeature("Core")]
     [AllureId(123)]
@@ -53,5 +52,16 @@ public class Tests
 ### Installation and Usage
 - Download from Nuget with all dependencies
 - Configure allureConfig.json
-- Set `[AllureNUnit]` attribute under test fixture
-- Use other [attributes](https://github.com/unickq/allure-nunit/wiki/Attributes) if needed
+- Apply the `[AllureNUnit]` attribute to test fixtures
+- Use other attributes in `NUnit.Allure.Attributes` if needed
+
+#### For users of Mac with Apple silicon
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```

--- a/Allure.Net.Commons/README.md
+++ b/Allure.Net.Commons/README.md
@@ -5,6 +5,18 @@ Can be targeted either by legacy .net 4.5+ or .net standard 2.* projects.
 
 Use this library to create custom Allure adapters for .Net test frameworks.
 
+### Note for users of Mac with Apple silicon
+
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 ### Configuration
 Allure lifecycle is configured via json file with default name `allureConfig.json`. NuGet package installs `allureConfig.Template.json` which you can use as an example. There are 2 ways to specify config file location:
 -  set ALLURE_CONFIG environment variable to the full path of json config file. This option is preferable for .net core projects which utilize nuget libraries directly from nuget packages folder. See this example of setting it via code: https://github.com/allure-framework/allure-csharp/blob/bdf11bd3e1f41fd1e4a8fd22fa465b90b68e9d3f/Allure.Commons.NetCore.Tests/AllureConfigTests.cs#L13-L15

--- a/Allure.SpecFlowPlugin/README.md
+++ b/Allure.SpecFlowPlugin/README.md
@@ -12,6 +12,18 @@ Please use corresponding NuGet package version.
 Install  [Allure.SpecFlow](https://www.nuget.org/packages/Allure.SpecFlow)
 nuget package according to your Specflow version.
 
+#### For users of Mac with Apple silicon
+
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 ### Configuration
 
 For Specflow 3 please add or update the following section in your specflow.json:

--- a/Allure.XUnit/README.md
+++ b/Allure.XUnit/README.md
@@ -193,6 +193,17 @@ Use [`AllureAttachments`](AllureAttachments.cs) class with its methods. (Attachm
 
 ## Known issues and limitations
 
+### Rosetta is required for users on Mac with Apple silicon
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 ### allureConfig.json is required even if no config properties are present
 
 The configuration file must be present in the output directory. Allure.XUnit


### PR DESCRIPTION
### Context
AspectInjector 2.8.2 uses an ARM64 version of the utility on mac with M1. This version doesn't work - it gets immediately killed by the OS.
Version 2.8.1 uses x86-64 version on all mac architectures. On M1 chips it works via Rosetta.

We need 2.8.2 because it's bundled with Mono.Cecil 0.11.5 that contains the PdbChecksum fix (https://github.com/jbevain/cecil/pull/810).

We continue using AspectInjector 2.8.2 to build the packages in this repo, but this PR adds an extra step in our publishing pipeline to lower the AspectInjector requirement back to 2.8.1 for our users.

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
