### PR TITLE
Allow SpecFlow to continue even if Harmony patch fails

### DIFF
--- a/Allure.SpecFlowPlugin/AllureBindingInvoker.cs
+++ b/Allure.SpecFlowPlugin/AllureBindingInvoker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.IO;
 using Allure.Net.Commons;
 using Allure.SpecFlowPlugin.SelectiveRun;
 using TechTalk.SpecFlow;
@@ -43,7 +44,8 @@ namespace Allure.SpecFlowPlugin
         {
             this.testRunnerManager = testRunnerManager;
             AllureSpecFlowPatcher.EnsureTestPlanSupportInjected(
-                unitTestRuntimeProvider
+                unitTestRuntimeProvider,
+                WriteErrorToFileSafe
             );
         }
 
@@ -73,6 +75,15 @@ namespace Allure.SpecFlowPlugin
                 testTracer,
                 out duration
             );
+        }
+
+        static void WriteErrorToFileSafe(Exception e)
+        {
+            try
+            {
+                File.WriteAllText(".allure_patch_error", e.ToString());
+            }
+            catch (Exception) { }
         }
 
         (object, TimeSpan) ProcessHook(

--- a/Allure.SpecFlowPlugin/SelectiveRun/AllureSpecFlowPatcher.cs
+++ b/Allure.SpecFlowPlugin/SelectiveRun/AllureSpecFlowPatcher.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -13,7 +14,8 @@ namespace Allure.SpecFlowPlugin.SelectiveRun
         static bool isTestPlanSupportInjected= false;
 
         internal static void EnsureTestPlanSupportInjected(
-            IUnitTestRuntimeProvider unitTestRuntimeProvider
+            IUnitTestRuntimeProvider unitTestRuntimeProvider,
+            Action<Exception> logError
         )
         {
             if (isTestPlanSupportInjected)
@@ -21,7 +23,14 @@ namespace Allure.SpecFlowPlugin.SelectiveRun
                 return;
             }
 
-            InjectTestPlanSupport(unitTestRuntimeProvider);
+            try
+            {
+                InjectTestPlanSupport(unitTestRuntimeProvider);
+            }
+            catch (Exception e)
+            {
+                logError(e);
+            }
             isTestPlanSupportInjected = true;
         }
 


### PR DESCRIPTION
Closes #436

### Context
This PR allows a SpecFlow test run to continue if Harmony patching fails (e.g., for net8.0, see #434).

Ideally, a warning should've been logged, but no such API exists in SpecFlow. The best I came up with was to log the last exception in a file in the output directory.

### Motivation

The main motivation is to enable users who don't need selective run feature to use Allure SpecFlow with net8.0 until the MonoMod fix for net8.0 is released.

