### PR TITLE
Update READMEs and project links

### DIFF
--- a/Allure.NUnit/Allure.NUnit.csproj
+++ b/Allure.NUnit/Allure.NUnit.csproj
@@ -8,7 +8,7 @@
         <PackageId>Allure.NUnit</PackageId>
         <AssemblyName>Allure.NUnit</AssemblyName>
         <RootNamespace>NUnit.Allure</RootNamespace>
-        <PackageProjectUrl>https://www.nuget.org/packages/Allure.NUnit</PackageProjectUrl>
+        <PackageProjectUrl>https://allurereport.org/</PackageProjectUrl>
         <PackageTags>allure nunit</PackageTags>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Allure.NUnit/README.md
+++ b/Allure.NUnit/README.md
@@ -1,73 +1,46 @@
 # Allure NUnit adapter
-NUnit adapter for Allure Framework
 
 [![Nuget](https://img.shields.io/nuget/v/Allure.NUnit?style=flat)](https://www.nuget.org/packages/Allure.NUnit)
 [![Nuget pre](https://img.shields.io/nuget/vpre/Allure.Nunit?style=flat)](https://www.nuget.org/packages/Allure.NUnit)
 
 ![Nuget downloads](https://img.shields.io/nuget/dt/allure.nunit?label=downloads&style=flat)
 
+> An Allure adapter for [NUnit](https://nunit.org/).
 
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
-![Allure report](https://raw.githubusercontent.com/unickq/allure-nunit/master/AllureScreen.png)
+- Learn more about Allure Report at [https://allurereport.org](https://allurereport.org)
+- 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report
+- ❓ [Questions and Support](https://github.com/orgs/allure-framework/discussions/categories/questions-support) – get help from the team and community
+- 📢 [Official announcements](https://github.com/orgs/allure-framework/discussions/categories/announcements) –  stay updated with our latest news and updates
+- 💬 [General Discussion](https://github.com/orgs/allure-framework/discussions/categories/general-discussion) – engage in casual conversations, share insights and ideas with the community
+- 🖥️ [Live Demo](https://demo.allurereport.org/) — explore a live example of Allure Report in action
 
+---
 
-### [Code examples](https://github.com/allure-framework/allure-csharp/tree/main/Allure.NUnit.Examples):
+## Quick start
 
-```cs
-[TestFixture(Author = "unickq", Description = "Examples")]
-[AllureNUnit]
-[AllureLink("https://github.com/allure-framework/allure-csharp")]
-public class Tests
-{
-    [OneTimeSetUp]
-    public void ClearResultsDir()
-    {
-        AllureLifecycle.Instance.CleanupResultDirectory();
-    }
+- Install the Allure.NUnit package.
+- Configure allureConfig.json.
+- Apply the `[AllureNUnit]` attribute to test fixtures.
+- Use other attributes in `NUnit.Allure.Attributes` if needed.
+- Use the functions in `Allure.Net.Commons.AllureApi` if needed.
 
-    [AllureStep("This method is just saying hello")]
-    private void SayHello()
-    {
-        Console.WriteLine("Hello!");
-    }
+## Further readings
 
-    [Test]
-    [AllureTag("NUnit", "Debug")]
-    [AllureIssue("GitHub#1", "https://github.com/allure-framework/allure-csharp")]
-    [AllureSeverity(SeverityLevel.critical)]
-    [AllureFeature("Core")]
-    [AllureId(123)]
-    public void EvenTest([Range(0, 5)] int value)
-    {
-        // An attribute-based step
-        SayHello();
-            
-        // A lambda step
-        AllureApi.Step(
-            "Validate calculations",
-            () =>
-            {
-                Assert.IsTrue(value % 2 == 0, $"Oh no :( {value} % 2 = {value % 2}");
-            }
-        );
-    }
-}
-```
+Learn more from [the documentation for Allure NUnit](https://allurereport.org/docs/nunit/).
 
-#### NUnit.Allure.Core.StepsHelper deprecation
+Some examples are available [here](https://github.com/allure-framework/allure-csharp/tree/main/Allure.NUnit.Examples).
+
+## Notes
+
+### NUnit.Allure.Core.StepsHelper deprecation
 
 The new `Allure.Net.Commons.AllureApi` facade class was designed specificially
 for test authors to enhance the Allure report. Prefer using functions in this
 class over the ones from `NUnit.Allure.Core.StepsHelper`.
 
-### Installation and Usage
-- Download from Nuget with all dependencies.
-- Configure allureConfig.json.
-- Apply the `[AllureNUnit]` attribute to test fixtures.
-- Use other attributes in `NUnit.Allure.Attributes` if needed.
-- Use functions in `Allure.Net.Commons.AllureApi` if needed.
-
-#### For users of Mac with Apple silicon
+### For users of Mac with Apple silicon
 If you're developing on a Mac machine with Apple silicon, make sure you have
 Rosetta installed. Follow this article for the instructions:
 https://support.apple.com/en-us/HT211861

--- a/Allure.Net.Commons/Allure.Net.Commons.csproj
+++ b/Allure.Net.Commons/Allure.Net.Commons.csproj
@@ -6,7 +6,7 @@
         <Authors>Alexander Bakanov, Nikolay Laptev</Authors>
         <Product />
         <Description>Provides common facilities to build allure integrations for .NET test frameworks</Description>
-        <PackageProjectUrl>https://www.nuget.org/packages/Allure.Net.Commons</PackageProjectUrl>
+        <PackageProjectUrl>https://allurereport.org/</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>allure</PackageTags>
         <PackageIcon>Allure-Color.png</PackageIcon>

--- a/Allure.Net.Commons/Allure.Net.Commons.csproj
+++ b/Allure.Net.Commons/Allure.Net.Commons.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>true</IsPackable>
-        <Authors>Alexander Bakanov, Nikolay Laptev</Authors>
+        <Authors>Alexander Bakanov, Nikolay Laptev, Maksim Stepanov</Authors>
         <Product />
         <Description>Provides common facilities to build allure integrations for .NET test frameworks</Description>
         <PackageProjectUrl>https://allurereport.org/</PackageProjectUrl>

--- a/Allure.Net.Commons/README.md
+++ b/Allure.Net.Commons/README.md
@@ -1,11 +1,23 @@
-# Allure.Net.Commons  [![](http://img.shields.io/nuget/vpre/Allure.Net.Commons.svg?style=flat)](https://www.nuget.org/packages/Allure.Net.Commons)
+# Allure.Net.Commons
+[![](http://img.shields.io/nuget/vpre/Allure.Net.Commons.svg?style=flat)](https://www.nuget.org/packages/Allure.Net.Commons)
 .Net implementation of [Allure java-commons](https://github.com/allure-framework/allure-java/tree/master/allure-java-commons).
 
-Use this library to create custom Allure adapters for .NET test frameworks.
+> Allure.Net.Commons is a library for creating custom Allure adapters for .NET test frameworks.
 
-Can be used by any project targeting a netstandard2.0 compatible framework
-including .NET Framework 4.6.1+, .NET Core 2.0+, .NET 5.0+ and more. See the
-full list [here](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version).
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
+
+- Learn more about Allure Report at [https://allurereport.org](https://allurereport.org)
+- 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report
+- ❓ [Questions and Support](https://github.com/orgs/allure-framework/discussions/categories/questions-support) – get help from the team and community
+- 📢 [Official announcements](https://github.com/orgs/allure-framework/discussions/categories/announcements) –  stay updated with our latest news and updates
+- 💬 [General Discussion](https://github.com/orgs/allure-framework/discussions/categories/general-discussion) – engage in casual conversations, share insights and ideas with the community
+- 🖥️ [Live Demo](https://demo.allurereport.org/) — explore a live example of Allure Report in action
+
+---
+
+The library can be used by any project targeting a netstandard2.0 compatible
+framework including .NET Framework 4.6.1+, .NET Core 2.0+, .NET 5.0+ and more.
+See the full list [here](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version).
 
 ## Note for users of Mac with Apple silicon
 
@@ -20,10 +32,10 @@ You may also install Rosetta via the CLI:
 ```
 
 ## Configuration
-Allure lifecycle is configured via json file with default name `allureConfig.json`. NuGet package installs `allureConfig.Template.json` which you can use as an example. There are 2 ways to specify config file location:
--  set ALLURE_CONFIG environment variable to the full path of json config file. This option is preferable for .net core projects which utilize nuget libraries directly from nuget packages folder. See this example of setting it via code: https://github.com/allure-framework/allure-csharp/blob/bdf11bd3e1f41fd1e4a8fd22fa465b90b68e9d3f/Allure.Commons.NetCore.Tests/AllureConfigTests.cs#L13-L15
+Allure lifecycle is configured via a json file with the default name `allureConfig.json`. NuGet package installs `allureConfig.Template.json` which you can use as an example. There are 2 ways to specify config file location:
+-  set ALLURE_CONFIG environment variable to the full path of json config file. This option is preferable for .net core projects which utilize nuget libraries directly from nuget packages folder. See this example of setting it in the code: https://github.com/allure-framework/allure-csharp/blob/bdf11bd3e1f41fd1e4a8fd22fa465b90b68e9d3f/Allure.Commons.NetCore.Tests/AllureConfigTests.cs#L13-L15
 
-- place `allureConfig.json` to the location of `Allure.Commons.dll`. This option can be used with .net classic projects which copy all referenced package libraries into binary folder. Do not forget to set 'Copy to Output Directory' property to 'Copy always' or 'Copy if newer' in your test project or set it in .csproj:
+- place `allureConfig.json` to the location of `Allure.Net.Commons.dll`. This option can be used with .net classic projects which copy all referenced package libraries into binary folder. Do not forget to set 'Copy to Output Directory' property to 'Copy always' or 'Copy if newer' in your test project or set it in .csproj:
    ```xml
    <ItemGroup>
      <None Update="allureConfig.json">
@@ -45,7 +57,7 @@ Allure configuration section is used to setup output directory and link patterns
   "allure": {
     "directory": "allure-results", // optional, default value is "allure-results"
     "title": "custom run title", // optional
-    "links": //optional 
+    "links": //optional
     [
       "https://example.org/{link}",
       "https://example.org/{issue}",
@@ -59,15 +71,14 @@ All link pattern placeholders will be replaced with URL value of corresponding l
 
 `link(type: "issue", url: "BUG-01") => https://example.org/BUG-01`
 
-## The end user API
+## Runtime API
 
-This API is designed for test authors. Use it to enhance the report created
-from your tests.
+Use this API it to enhance the report at runtime.
 
 ### The AllureApi facade
 
-Use the `Allure.Net.Commons.AllureApi` class to access an end user's runtime
-API.
+Use the `Allure.Net.Commons.AllureApi` class to access the most commonly used
+functions.
 
 #### Metadata
 
@@ -118,10 +129,14 @@ API.
 * AddAttachment - adds an attachment to the current step, fixture, or test.
 * AddScreenDiff - adds needed artifacts to the current test case to be used with [screen-diff-plugin](https://github.com/allure-framework/allure2/tree/master/plugins/screen-diff-plugin)
 
+### The ExtendedApi facade
+
+Use this class to access some less commonly used functions.
+
 #### Explicit step management
 
 > [!NOTE]
-> Use these functions only if lambda steps doesn't suit your needs.
+> Use the functions below only if lambda steps doesn't suit your needs.
 
 * `StartStep(string): void`
 * `StartStep(string, Action<StepResult>): void`
@@ -147,7 +162,7 @@ API.
 #### Explicit fixture management
 
 > [!NOTE]
-> Use these functions only if lambda fixtures doesn't suit your needs.
+> Use the functions below only if lambda fixtures doesn't suit your needs.
 
 * `StartBeforeFixture(string): void`
 * `StartAfterFixture(string): void`

--- a/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
+++ b/Allure.SpecFlowPlugin/Allure.SpecFlowPlugin.csproj
@@ -8,7 +8,7 @@
         <Authors>Alexander Bakanov</Authors>
         <Product />
         <Description>Generates Allure report result files for SpecFlow test run</Description>
-        <PackageProjectUrl>https://www.nuget.org/packages/Allure.SpecFlow</PackageProjectUrl>
+        <PackageProjectUrl>https://allurereport.org/</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageIcon>Allure-SF-Color.png</PackageIcon>
         <PackageTags>specflow allure</PackageTags>

--- a/Allure.SpecFlowPlugin/README.md
+++ b/Allure.SpecFlowPlugin/README.md
@@ -1,16 +1,38 @@
-## SpecFlow Adapter  [![](http://img.shields.io/nuget/vpre/Allure.SpecFlow.svg?style=flat)](https://www.nuget.org/packages/Allure.SpecFlow)
+## SpecFlow Adapter
 
-Currently supports [SpecFlow](http://specflow.org/) v2.1 - 3.9.*
+[![Nuget](https://img.shields.io/nuget/v/Allure.SpecFlow?style=flat)](https://www.nuget.org/packages/Allure.SpecFlow)
+[![Nuget pre](https://img.shields.io/nuget/vpre/Allure.SpecFlow?style=flat)](https://www.nuget.org/packages/Allure.SpecFlow)
 
-See [Allure report](https://allure-secondary.z23.web.core.windows.net/)
-generated from https://github.com/allure-framework/allure-csharp/tree/main/Allure.Features
+![Nuget downloads](https://img.shields.io/nuget/dt/allure.specflow?label=downloads&style=flat)
 
-Please use corresponding NuGet package version.
+> An Allure adapter for [SpecFlow](https://specflow.org/).
 
-### Installation
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
-Install  [Allure.SpecFlow](https://www.nuget.org/packages/Allure.SpecFlow)
+- Learn more about Allure Report at [https://allurereport.org](https://allurereport.org)
+- 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report
+- ❓ [Questions and Support](https://github.com/orgs/allure-framework/discussions/categories/questions-support) – get help from the team and community
+- 📢 [Official announcements](https://github.com/orgs/allure-framework/discussions/categories/announcements) –  stay updated with our latest news and updates
+- 💬 [General Discussion](https://github.com/orgs/allure-framework/discussions/categories/general-discussion) – engage in casual conversations, share insights and ideas with the community
+- 🖥️ [Live Demo](https://demo.allurereport.org/) — explore a live example of Allure Report in action
+
+---
+
+The plugin currently supports [SpecFlow](http://specflow.org/) v2.1 - 3.9.*
+
+### Quick start
+
+1. Install the [Allure.SpecFlow](https://www.nuget.org/packages/Allure.SpecFlow)
 nuget package according to your Specflow version.
+2. Add the following entry to your `specflow.json`:
+    ```json
+    {
+      "stepAssemblies": [
+        {"assembly": "Allure.SpecFlowPlugin"}
+      ]
+    }
+    ```
+3. Run the tests.
 
 #### For users of Mac with Apple silicon
 
@@ -24,230 +46,20 @@ You may also install Rosetta via the CLI:
 /usr/sbin/softwareupdate --install-rosetta --agree-to-license
 ```
 
-### Configuration
+### Further readings
 
-For Specflow 3 please add or update the following section in your specflow.json:
-
-```json      
-{
-  "stepAssemblies": [
-    { "assembly": "Allure.SpecFlowPlugin" }
-  ]
-}
-```
-
-The plugin uses allureConfig.json extended with custom sections that are
-described below.
-
-#### Custom host name
-
-In case if you want to customize host name which is displayed in Allure Timeline
-section, please configure `allure.title` property in json configuraion file.
-
-```json
-{
-    "allure": {
-        "title": "My title"
-    }
-}
-```
-
-#### If you use NUnit
-
-The default value for allure.directory in allureConfig.json is "allure-results".
-The default working directory in NUnit 3.* depends on what runner you use.
-
-If you don't want to place allure results into NUnit default working folder
-please either set absolute path in allure.config or set working directory for
-NUnit in your test setup, e.g.:
-
-``` csharp
-[OneTimeSetUp]
-public void Init()
-{
-   Environment.CurrentDirectory = Path.GetDirectoryName(GetType().Assembly.Location);
-}
-```
-
-### Usage
-
-Just run your SpecFlow scenarios and find the `allure-results` folder ready to
-generate Allure report.
-
-### Features
-
-#### Grouping
-
-You can structure your scenarios in 3 Allure hierarchies using feature and
-scenario tags.
-Please read [report structure](https://docs.qameta.io/allure/latest/#_report_structure)
-Allure documentation section for additional details. Hierarchies consist of
-the following levels:
-
-**Suites**
-* Parent Suite
-* * Suite
-* * * Sub Suite
-
-**Behaviors**
-* Epic
-* * Feature
-* * * Story
-
-**Packages**
-* Package
-* * Class
-* * * Method
-
-The plugin uses `allure:grouping` configuration section to parse tags with the
-regular expression. If the expression contains the group, it will be used as
-hierarchy level name otherwise entire match will be used. E.g:
-
-`^mytag.*` : any tags starting with `@mytag` will be used for grouping.
-
-`^type:(ui|api)` : `@ui` or `@api` tags from regex pattern will be used for
-grouping.
-
-Check this [config example](https://github.com/allure-framework/allure-csharp/blob/main/Tests.SpecRun/allureConfig.json)
-as a starting point.
-
-#### Links
-You can add links to your scenarios using tags. Tag and link patterns can be
-configured in `allureConfig.json`
-
-``` json
-{
-  "allure": {
-    "links": [
-      "https://myissuetracker.org/{issue}",
-      "https://mytestmanagementsystem.org?test={tms}"
-    ]
-  },
-  "specflow": {
-    "links": {
-      "link": "^link:(.+)",
-      "issue": "^\\d+",
-      "tms": "^tms:(\\d+)"
-    }
-  }
-}
-```
-
-The following scenario
-
-``` cucumber
-@123456 @tms:42 @link:http://example.org 
-Scenario: I do like click on links in Allure report 
-```
-
-will have three links in Allure report:
-[123456](https://myissuetracker.org/123456),
-[42](https://mytestmanagementsystem.org?test=tms-42) and http://example.org.
-
-Links generated dynamically during the tests can be added in code via
-AllureLifecycle. The next example adds the [Example link](http://example.com)
-link at runtime:
-
-``` c#
-AllureLifecycle.Instance.UpdateTestCase(tc =>
-{
-    tc.links.Add(new Link()
-    {
-        name = "Example link",
-        url = "http://example.com"
-    });
-});
-```
-
-#### Severity
-You can add Severity for your scenarios using tags. It can be configured in
-`allureConfig.json`:
-
-``` json
- "labels": {
-      "severity": "^(normal|blocker|critical|minor|trivial)"
-    },
-```
-
-The following scenario
-
-``` cucumber
-@critical
-Scenario: ....
-```
-
-sets the current scenario's severity in Allure report as Blocker.
-
-#### Label
-
-You can add allure labels for your scenarios using tags. It can be configured
-in `allureConfig.json`:
-
-``` json
- "labels": {
-      "label": "^label:([\\w]+):(.+)"
-    },
-```
-
-The following scenario
-
-``` cucumber
-@label:layer:e2e: @label:allure_id:123
-Scenario: ....
-```
-
-sets the current scenario's layer as e2e and Id as 123 in Allure report
-
-#### Tables conversion
-
-Table arguments in SpecFlow steps can be converted either to step
-csv-attacments or step parameters in the Allure report. The conversion is
-configurable in `specflow:stepArguments` config section.
-
-With `specflow:stepArguments:convertToParameters` set to `true` the following
-table arguments will be represented as parameters:
-
-* one row tables
-* two column tables with the headers matching both
-  `specflow:stepArguments:paramNameRegex` and
-  `specflow:stepArguments:paramValueRegex` regular expressions.
-
-<table>
-<th>SpecFlow</th>
-<th>Allure</th>
-<tr>
-<td>
-
-![](https://github.com/allure-framework/allure-csharp/blob/main/img/wiki-step-all.PNG)
-
-</td>
-<td>
-
-![](https://github.com/allure-framework/allure-csharp/blob/main/img/allure-step-all.PNG)
-
-</td>
-</tr>
-</table>
-
-#### Attachments
-
-You can add attachments to an Allure report from your step bindings:
-
-```csharp
-using Allure.Net.Commons;
-...
-Allure.AddAttachment(path, "Attachment Title");
-// or
-Allure.AddAttachment("Attachment Title", "application/txt", "path");
-// where "application/txt" - the type of your attachment
-```
+Learn more from [the documentation for Allure SpecFlow](https://allurereport.org/docs/specflow/).
 
 ### Known issues
 
-#### Selective run might not work
+#### Selective run issues
 
-Under rare circumstances selective run feature might not work.
-Issue [#369] contains some additional details.
+Selective run doesn't work in .NET 8.0 until the support is added to
+Monomod.Core.
 
-If you are affected by this, you may try to switch to the `Debug` configuration
-as a workaround until we come up with a solution.
+Additionally, it might not work under other rare circumstances.
+Issue [#369] contains some additional details. If you are affected by this, you
+may try to switch to the `Debug` configuration as a workaround until we come up
+with a solution.
+
+[#369]: https://github.com/allure-framework/allure-csharp/issues/369

--- a/Allure.XUnit/Allure.XUnit.csproj
+++ b/Allure.XUnit/Allure.XUnit.csproj
@@ -7,7 +7,7 @@
         <Authors>Shumakov Ivan</Authors>
         <Description>Allure.XUnit</Description>
         <PackageIcon>Allure-X-Color.png</PackageIcon>
-        <PackageProjectUrl>https://www.nuget.org/packages/Allure.XUnit</PackageProjectUrl>
+        <PackageProjectUrl>https://allurereport.org/</PackageProjectUrl>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageTags>allure xunit</PackageTags>
     </PropertyGroup>

--- a/Allure.XUnit/README.md
+++ b/Allure.XUnit/README.md
@@ -1,213 +1,48 @@
 # Allure.XUnit
 
-[![Nuget](https://img.shields.io/nuget/v/Allure.XUnit)](https://www.nuget.org/packages/Allure.XUnit/)
+[![Nuget](https://img.shields.io/nuget/v/Allure.XUnit?style=flat)](https://www.nuget.org/packages/Allure.XUnit)
+[![Nuget pre](https://img.shields.io/nuget/vpre/Allure.XUnit?style=flat)](https://www.nuget.org/packages/Allure.XUnit)
 
-Allure.XUnit helps you to create Allure reports from your xUnit tests.
+![Nuget downloads](https://img.shields.io/nuget/dt/allure.xunit?label=downloads&style=flat)
 
-Allure.XUnit supports .NET Core 2.0 or later, and any .NET runtime compatible
-with .NET Standard 2.1.
+> An Allure adapter for [xUnit.net](https://xunit.net/).
 
-## How to run
+Allure.XUnit supports .NET Core 2.0 or later, or any .NET runtime that
+implements .NET Standard 2.1.
+
+## Quick start
 
 Install the Allure.XUnit package and run the tests normally. In many cases
 allure should start automatically. The result files are created in the
 `allure-results` directory in the target directory.
 If that didn't happen, check out the `Running tests in a CI pipeline` section.
 
-### Configuration
+## Further readings
 
-If you need to configure allure-xunit, create `allureConfig.json` and make sure
-it is copied to the output directory:
+Learn more from [the documentation for Allure NUnit](https://allurereport.org/docs/nunit/).
 
-  - In Visual Studio select the file and set the following properties:
-      - Build Action: Content
-      - Copy to Output Directory: Always/Copy if newer
-    OR
-  - In the `.csproj` file make sure the following entry exists:
-    ```xml
-    <ItemGroup>
-        <Content Include="allureConfig.json">
-            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-        </Content>
-    </ItemGroup>
-    ```
+Some examples are available [here](https://github.com/allure-framework/allure-csharp/tree/main/Allure.XUnit.Examples).
 
-An example of the config:
-
-```json
-{
-    "allure": {
-        "allure-directory": "allure-results",
-        "links": [
-            "https://github.com/allure-framework/allure-csharp/issues/{issue}"
-        ]
-    }
-}
-```
-
-### Running tests in a CI pipeline
-
-There might be a chance another xunit reporter kicks in disabling allure. This
-typically happens in a CI pipeline when a pipeline-specific reporter detects
-the CI environment and signals xunit that it's ready to be used. Xunit's
-reporter pick is unreliable in such a case.
-
-If that happens, you should explicitly tell xunit to use the `allure` reporter.
-How exactly - depends on what runner you use. For the most popular one -
-`xunit.runner.visualstudio` - you either specify it via the CLI argument:
-
-```
-dotnet test -- RunConfiguration.ReporterSwitch=allure
-```
-
-Or use a `.runsettings` file:
-
-```xml
-<?xml version="1.0" encoding="utf-8"?>
-<RunSettings>
-  <RunConfiguration>
-    <ReporterSwitch>allure</ReporterSwitch>
-  </RunConfiguration>
-</RunSettings>
-```
-
-Now pass the file to `dotnet test`:
-
-```
-dotnet test -s <path-to-.runsettings-file>
-```
-
-Or specify its path using your IDE.
-
-By default Allure.XUnit tries to use additional environmentally enabled
-reporter (if any), so your tests are reported both to allure and, say,
-TeamCity. Due to how xunit configuration works, that behavior occures
-regardless of xunit's `NoAutoReporters` setting. If you want to disable this
-behavior, check out the `Configuring a secondary reporter` section.
-
-### Configuring a secondary reporter
-
-Use the `xunitRunnerReporter` property of `allureConfig.json` to control
-an additional reporter used by Allure.XUnit:
-
-```json
-{
-    "allure": {
-        "xunitRunnerReporter": "auto|none|<switch>|<AQ-classname>"
-    }
-}
-```
-
-We support the following values:
-  - `auto` - default value. Allure.XUnit uses the first environmentally
-    enabled reporter it finds.
-  - `none` - use this value to disable an additional reporter.
-  - `<switch>` - Allure.XUnit looks for the reporter with the specified
-    runner switch. If such reporter exists, it's used. Otherwise, the error is
-    thrown.
-  - `<AQ-classname>` - the assembly qualified class name is used to find the
-    reporter's class. If no such class can be found, the error is thrown.
-
-
-## Attributes:
-
-The following attributes are at your disposal:
-
-* AllureDescription
-* AllureParentSuite
-* AllureFeature
-* AllureTag
-* AllureSeverity
-* AllureIssue
-* AllureOwner
-* AllureSuite
-* AllureSubSuite
-* AllureLink
-* AllureEpic
-* AllureLabel
-* AllureId
-
-All attributes are optional.
-
-### Attributes usage
-
-Most of the attributes can be used both on methods and classes.
-
-| Attribute | Method | Class |
-|:------------------|:---:|:---:|
-| AllureDescription |  x  |     |
-| AllureParentSuite |  x  |  x  |
-| AllureFeature     |  x  |  x  |
-| AllureTag         |  x  |  x  |
-| AllureSeverity    |  x  |  x  |
-| AllureIssue       |  x  |  x  |
-| AllureOwner       |  x  |  x  |
-| AllureSuite       |  x  |  x  |
-| AllureSubSuite    |  x  |  x  |
-| AllureLink        |  x  |  x  |
-| AllureEpic        |  x  |  x  |
-| AllureLabel       |  x  |  x  |
-| AllureId          |  x  |     |
-
-To override attribute value you can use `overwrite` param in attribute definition.
-In other case multiple values will be written in test results.
-
-Example:
-```c#
-[AllureSuite("Suite A")]
-public class TestClass
-{
-    [Fact(DisplayName = "Test Name")]
-    [AllureSuite("Suite B", overwrite: true))]
-    public void TestMethod
-    {
-    }
-}
-```
+## Notes
 
 ### AllureXunit and AllureXunitTheory deprecation
-Previously all test methods had to be marked with the AllureXunit or 
+Previously all test methods had to be marked with the AllureXunit or
 AllureXunitTheory attributes. There is no such need anymore.
 These attributes are still supported, but we advice you to use the built-in
 Fact and Theory attributes instead.
 
 The AllureXunit and AllureXunitTheory attributes might be removed in future releases.
 
-## Steps
-Use `AllureStepAttribute`, `AllureBeforeAttribute`, `AllureAfterAttribute`
-
-See [Examples](../Allure.XUnit.Examples/ExampleStepAttributes.cs).
-
 ### Allure.XUnit.StepExtensions deprecation
 There is no more need to use separate Allure.XUnit.StepExtensions package. You
 should remove it from dependencies and use attributes from
 [Allure.XUnit.Attributes.Steps namespace](Attributes/Steps) directly.
-
-```c#
-using Allure.XUnit.Attributes.Steps;
-
-...
-
-    [AllureStep("Check that {someNumber} is the answer to life, the universe, and everything")]
-    private void NestedStep([Name("number")] int someNumber, [Skip] bool skippedBoolean = true)
-    {
-        Assert.Equal(42, someNumber);
-    }
-```
 
 ### Allure.Xunit.Steps deprecation
 
 The new `Allure.Net.Commons.AllureApi` facade class was designed specificially
 for test authors to enhance the Allure report. Prefer using functions in this
 class over the ones from `Allure.Xunit.Steps`.
-
-## Attachments
-Use the [`Attachments`](Attachments.cs) class with its methods as well as
-attachment methods from the `Allure.Net.Commons.AllureApi` class.
-
-## Runtime API
-Use the functions from `Allure.Net.Commons.AllureApi` to enhance the report at
-runtime.
 
 ## Known issues and limitations
 
@@ -222,24 +57,19 @@ You may also install Rosetta via the CLI:
 /usr/sbin/softwareupdate --install-rosetta --agree-to-license
 ```
 
-### Arguments of some theories might be unreported
+### MonoMod.Core issues
 
-Under rare circumstances arguments of some theories might be missing in the
-report produced by allure-xunit. Issue [#369] contains some additional details.
+We rely on Harmony that in turn uses MonoMod.Core to:
 
-If you are affected by this, you may switch to the `Debug` configuration as a
-workaround until we come up with a solution.
+1. Report arguments of theories in rare case they aren't reported by xUnit.net itself.
+2. Implement selectie run.
 
-### Selective run might not work
+Sometimes MonoMod.Core fails to patch making those features unavailable. We
+know two such cases:
 
-Under rare circumstances selective run feature might not work.
+1. Running under .NET 8.0
+2. Running on ARM64
+
 Issue [#369] contains some additional details.
-
-If you are affected by this, you may try to switch to the `Debug` configuration
-as a workaround until we come up with a solution.
-
-## Examples
-
-See [Examples](../Allure.XUnit.Examples).
 
 [#369]: https://github.com/allure-framework/allure-csharp/issues/369

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-# Allure C# Integrations  
+# Allure C# Integrations
 
 [![Build](https://github.com/allure-framework/allure-csharp/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/allure-framework/allure-csharp/actions/workflows/build.yml)
 
+> This repository contains adapters for C# test frameworks.
+
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
+
+- Learn more about Allure Report at [https://allurereport.org](https://allurereport.org)
+- 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report
+- ❓ [Questions and Support](https://github.com/orgs/allure-framework/discussions/categories/questions-support) – get help from the team and community
+- 📢 [Official announcements](https://github.com/orgs/allure-framework/discussions/categories/announcements) –  stay updated with our latest news and updates
+- 💬 [General Discussion](https://github.com/orgs/allure-framework/discussions/categories/general-discussion) – engage in casual conversations, share insights and ideas with the community
+- 🖥️ [Live Demo](https://demo.allurereport.org/) — explore a live example of Allure Report in action
+
+---
 
 ### Integrations
 


### PR DESCRIPTION
This PR adds a common header to all README files. It also includes the following changes:

  - Documentation and examples are removed from README files. A link to the docs at allurereport.org is added instead.
  - The `PackageProjectUrl` is set to https://allurereport.org.

