### PR TITLE
#441 - Fix exit code 1 if Harmony patching failled

### DIFF
--- a/Allure.XUnit/AllureXunitPatcher.cs
+++ b/Allure.XUnit/AllureXunitPatcher.cs
@@ -1,5 +1,5 @@
-using System;
 using HarmonyLib;
+using System;
 using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -34,17 +34,17 @@ internal static class AllureXunitPatcher
             _logger.LogMessage(
                 "Patching is skipped: Xunit is already patched"
             );
-
             return;
         }
 
         _logger = runnerLogger;
+
         var patcher = new Harmony(ALLURE_ID);
-        _patchXunitTestRunnerConstructors(patcher);
+        PatchXunitTestRunnerCtors(patcher);
         _isPatched = true;
     }
 
-    private static void _patchXunitTestRunnerConstructors(Harmony patcher)
+    private static void PatchXunitTestRunnerCtors(Harmony patcher)
     {
         var testRunnerType = typeof(XunitTestRunner);
         var wasPatched = false;
@@ -57,11 +57,11 @@ internal static class AllureXunitPatcher
                     ctor,
                     prefix: new HarmonyMethod(
                         typeof(AllureXunitPatcher),
-                        nameof(_onTestRunnerCreating)
+                        nameof(OnTestRunnerCreating)
                     ),
                     postfix: new HarmonyMethod(
                         typeof(AllureXunitPatcher),
-                        nameof(_onTestRunnerCreated)
+                        nameof(OnTestRunnerCreated)
                     )
                 );
 
@@ -87,23 +87,21 @@ internal static class AllureXunitPatcher
         if (!wasPatched)
         {
             _logger.LogWarning(
-                "No constructors of {0} were pathched. Some theories may " +
+                "No constructors of {0} were patched. Some theories may " +
                 "miss their parameters in the report",
                 testRunnerType.Name
             );
         }
     }
 
-    private static void _onTestRunnerCreating(ITest test, ref string skipReason)
+    private static void OnTestRunnerCreating(ITest test, ref string skipReason)
     {
         if (!CurrentSink.SelectByTestPlan(test))
         {
-            skipReason = "Deselected by the testplan.";
+            skipReason = "Deselected by the test plan.";
         }
     }
 
-    private static void _onTestRunnerCreated(ITest test, object[] testMethodArguments)
-    {
+    private static void OnTestRunnerCreated(ITest test, object[] testMethodArguments) => 
         CurrentSink.OnTestArgumentsCreated(test, testMethodArguments);
-    }
 }


### PR DESCRIPTION
#441 - Fix exit code 1 if Harmony patching failled - use LogWarning instead LogError

_Additionally, the code style has been changed - filescoped namespace, explicit modifiers for better code readability_

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
