### PR TITLE
Set labeler trigger back to complete update

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,7 +1,7 @@
 name: "Set theme labels"
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   triage:


### PR DESCRIPTION
### Context
Set labeler's trigger back to pull_request_target to complete the transition to v5.
