### PR TITLE
Adding NUnit MultipleAssertException to default fail exceptions

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -27,7 +27,8 @@ namespace Allure.NUnit.Core
             AllureLifecycle.AllureConfiguration.FailExceptions ??= new()
             {
                 typeof(NUnitException).FullName,
-                typeof(AssertionException).FullName
+                typeof(AssertionException).FullName,
+                typeof(MultipleAssertException).FullName
             };
         }
 

--- a/Allure.Reqnroll/State/AllureReqnrollStateFacade.cs
+++ b/Allure.Reqnroll/State/AllureReqnrollStateFacade.cs
@@ -17,6 +17,8 @@ static class AllureReqnrollStateFacade
 
     const string ASSERT_EXC_NUNIT =
         "NUnit.Framework.AssertionException";
+    const string ASSERT_EXC_NUNIT_MULTIPLE = 
+        "NUnit.Framework.MultipleAssertException";
     const string ASSERT_EXC_XUNIT_NEW = // From v2.4.2 and onward.
         "Xunit.Sdk.IAssertionException";
     const string ASSERT_EXC_XUNIT_OLD = // Prior to v2.4.2
@@ -46,6 +48,7 @@ static class AllureReqnrollStateFacade
         Lifecycle.AllureConfiguration.FailExceptions ??= new()
         {
             ASSERT_EXC_NUNIT,
+            ASSERT_EXC_NUNIT_MULTIPLE,
             ASSERT_EXC_XUNIT_NEW,
             ASSERT_EXC_XUNIT_OLD,
             ASSERT_EXC_MSTEST

--- a/Allure.SpecFlow/AllureBindingInvoker.cs
+++ b/Allure.SpecFlow/AllureBindingInvoker.cs
@@ -27,7 +27,9 @@ namespace Allure.SpecFlowPlugin
             "Allure.SpecFlowPlugin.HAS_PLACEHOLDER_TESTCASE";
 
         const string ASSERT_EXC_NUNIT =
-        "NUnit.Framework.AssertionException";
+            "NUnit.Framework.AssertionException";
+        const string ASSERT_EXC_NUNIT_MULTIPLE = 
+            "NUnit.Framework.MultipleAssertException";
         const string ASSERT_EXC_XUNIT_NEW = // From v2.4.2 and onward.
             "Xunit.Sdk.IAssertionException";
         const string ASSERT_EXC_XUNIT_OLD = // Prior to v2.4.2
@@ -59,6 +61,7 @@ namespace Allure.SpecFlowPlugin
             AllureLifecycle.Instance.AllureConfiguration.FailExceptions ??= new()
             {
                 ASSERT_EXC_NUNIT,
+                ASSERT_EXC_NUNIT_MULTIPLE,
                 ASSERT_EXC_XUNIT_NEW,
                 ASSERT_EXC_XUNIT_OLD,
                 ASSERT_EXC_MSTEST


### PR DESCRIPTION
### Context
NUnit provides a method to perform multiple assertions without interrupting by failure. If any failures occur, a MultipleAssertException is thrown after all assertions have finished. Currently this exception is not included in default fail exceptions and this causes Allure to mark such test failures as broken tests.

Read more about multiple asserts here - https://docs.nunit.org/articles/nunit/writing-tests/assertions/multiple-asserts.html