### PR TITLE
Add Allure.Reqnroll test output handler support

### DIFF
--- a/Allure.Reqnroll/AllurePlugin.cs
+++ b/Allure.Reqnroll/AllurePlugin.cs
@@ -81,6 +81,7 @@ public class AllurePlugin : IRuntimePlugin
         yield return new StepStartedEventHandler(stateTransportFactory);
         yield return new StepFinishedEventHandler(stateTransportFactory);
         yield return new ScenarioFinishedEventHandle(stateTransportFactory);
+        yield return new TestOutputEventHandler(stateTransportFactory);
         yield return new FeatureFinishedEventHandler(stateTransportFactory);
 
         CrossBindingContextTransport stateTransportFactory() => new(

--- a/Allure.Reqnroll/Events/TestOutputEventHandler.cs
+++ b/Allure.Reqnroll/Events/TestOutputEventHandler.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Allure.Net.Commons;
+using Allure.ReqnrollPlugin.State;
+using Reqnroll.Events;
+
+namespace Allure.ReqnrollPlugin.Events;
+
+class TestOutputEventHandler : AllureReqnrollEventHandler<OutputAddedEvent>
+{
+    public TestOutputEventHandler(
+        Func<CrossBindingContextTransport> stateStorageFactory
+    ) : base(stateStorageFactory)
+    {
+    }
+
+    protected override void HandleInAllureContext(OutputAddedEvent eventData) {
+        AllureReqnrollStateFacade.AddOutput(
+            eventData.Text + "\n"
+        );
+    }
+}


### PR DESCRIPTION
### Context
Usage of the built in reqnroll test output helper was ignored, and no event was in place to handle these outputs. As text based test output can be extremely useful to help diagnose issues, this was a hard requirement for us to migrate from SpecFlow and LivingDoc to Reqnroll and Allure Reports.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests **TBD**

_Unit tests are still to be updated, i just wanted to get opinions on how better this could potentially be implemented._ 

#### Notes
I really didn't want to modify the Allure.Net.Commons project in order to enable support for this, however i did want to ensure that test outputs can be captured in as many cases as possible, without each write to these outputs being placed into a single file - hence the OutputCache static property that I really didn't want to need.

Any suggestions / improvements here are of course welcome. This PR is a major step to towards us being able to implement Allure instead of LivingDoc for our team, so hopefully we can figure out a way to get this in, otherwise we might have to fork this 😊

Usage of the ExecutableItem as a key for the dictionary ensures support for parallel test executions **within a container**, however there is limitations on a single container I can't seem to identify exactly the purpose of the container, or when multiple containers might exist, any advice here would be great, and I can then adapt this to work for many containers if required.

 #### Preview
A preview of what this looks like in the test overview is like so: 
![msedge_oOmb02boRr](https://github.com/allure-framework/allure-csharp/assets/1707575/b4a3c4e0-d1f8-4e5a-9890-395ac0669ee5)

Usage is compatible with existing ReqnRoll / SpecFlow output helper: 
```c#
    readonly ITestOutputHelper outputHelper;
    public SomeClass(ITestOutputHelper outputHelper)
    {
        this.outputHelper = outputHelper;
    }
    [StepDefinition("Step with test output")] //Note that AfterFeature, AfterScenario, AfterStep (and before) all work as well
    public void StepWithTestOutput() => outputHelper.WriteLine("Test output message");
```

