### PR TITLE
chore: upgrade to net8.0 and C# 12 for development

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           dotnet-version: |
             3.1.x
-            6.0.x
+            8.0.x
 
       - name: 'Restore packages'
         run: |

--- a/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
+++ b/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <OutputType>Library</OutputType>
     </PropertyGroup>
 

--- a/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
+++ b/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
+++ b/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <RootNamespace>Allure.ReqnrollPlugin.Tests.Samples</RootNamespace>
     </PropertyGroup>

--- a/Allure.Reqnroll.Tests/Allure.Reqnroll.Tests.csproj
+++ b/Allure.Reqnroll.Tests/Allure.Reqnroll.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <RootNamespace>Allure.ReqnrollPlugin.Tests</RootNamespace>
     </PropertyGroup>

--- a/Allure.SpecFlow.Tests.Samples/Allure.SpecFlow.Tests.Samples.csproj
+++ b/Allure.SpecFlow.Tests.Samples/Allure.SpecFlow.Tests.Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -9,7 +9,7 @@
         <PackageReference Include="NUnit" Version="4.1.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="SpecFlow.SharedSteps" Version="3.0.7" />
-        
+
         <!-- SpecFlow.SharedSteps doesn't work with SpecFlow.Tools.MsBuild.Generation v3.9.58+  -->
         <PackageReference Include="SpecFlow" Version="3.9.52" />
         <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.52" />

--- a/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj
+++ b/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
-  
+
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="NUnit" Version="4.1.0" />

--- a/Allure.Xunit.Examples/Allure.Xunit.Examples.csproj
+++ b/Allure.Xunit.Examples/Allure.Xunit.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
 
     <!-- Common projects' properties -->
     <PropertyGroup>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
         <CheckEolTargetFramework>false</CheckEolTargetFramework>
         <IsPackable>false</IsPackable>
         <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
### Context
Currently, the test projects and the CI pipeline target .NET 6.0, which has reached its EOL in November 2024. This PR switches the development to use .NET 8.0 instead, which is the next LTR release with the EOL set to November 10, 2026.

Additionally, the PR upgrades the C# version to 12, which matches .NET 8.0 and unlocks a bunch of [new language features](https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12) to use in our code base.
