### PR TITLE
fix(nunit): properly report ignored test cases

### DIFF
--- a/Allure.NUnit.Examples/AllureIgnoredTest.cs
+++ b/Allure.NUnit.Examples/AllureIgnoredTest.cs
@@ -13,8 +13,8 @@ namespace Allure.NUnit.Examples
         {
             get
             {
-                yield return new TestCaseData("Ignore").SetName("{m}_NotExist");
-                yield return new TestCaseData("NotIgnore").SetName("{m}_NotExist ignored").Ignore("Test");
+                yield return new TestCaseData("NotIgnore").SetName("{m}_NotExist");
+                yield return new TestCaseData("Ignore").SetName("{m}_NotExist ignored").Ignore("Test");
             }
         }
 

--- a/Allure.NUnit.Examples/AllureIgnoredTest.cs
+++ b/Allure.NUnit.Examples/AllureIgnoredTest.cs
@@ -25,6 +25,14 @@ namespace Allure.NUnit.Examples
         }
 
 
+        [TestCase("a")]
+        [TestCase("b")]
+        [Ignore("Foo")]
+        public void IgnoredTestCase(string data)
+        {
+        }
+
+
         [Test]
         [TestCase("a")]
         [TestCase("b", Ignore = "Case")]


### PR DESCRIPTION
### Context

Suppose we have the following test fixture:

```csharp
using Allure.NUnit;
using Allure.NUnit.Attributes;
using NUnit.Framework;

[AllureNUnit, AllureDisplayIgnored]
public class IgnoredTestCases
{
    [TestCase("foo")]
    [TestCase("bar")]
    [Ignore("baz")]
    public void IgnoredTestMethod(string data)
    {
    }
}
```

When we run the tests and generate the report, the report will contain a single parameterless test result that corresponds to the test method (not a specific test case).

The PR fixes this issue by properly collecting ignored leaves from the test hierarchy provided by NUnit.

### Screenshots

Before:

<img width="974" height="325" alt="image" src="https://github.com/user-attachments/assets/b89eb7b8-c5a4-4275-90c3-a73508fbd150" />

After:

<img width="973" height="393" alt="image" src="https://github.com/user-attachments/assets/0cecdd07-fd80-49db-8553-4874c6edd2f8" />
