### PR TITLE
fix(nunit): remove assembly qualified names from fullName

### DIFF
--- a/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
@@ -24,6 +24,14 @@ class IdTests
     [TestCase(typeof(ClassWithoutNamespace), "Allure.Net.Commons.Tests:ClassWithoutNamespace")]
     [TestCase(typeof(MyClass), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass")]
     [TestCase(typeof(MyClass<>), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[T]")]
+    [TestCase(typeof(MyClass<string>), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[System.String]")]
+    [TestCase(
+        typeof(MyClass<MyClass<string, int>, MyClass<MyClass>>),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`2[" +
+            "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`2[System.String,System.Int32]," +
+            "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[" +
+                "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]]"
+    )]
     public void TestFullNameFromClass(Type targetClass, string expectedFullName)
     {
         Assert.That(
@@ -49,6 +57,8 @@ class IdTests
     {
         internal void GenericMethodOfGenericClass<V>(List<T> _, List<V> __) { }
     }
+
+    class MyClass<T1, T2> { }
 
     [TestCase(
         nameof(MyClass.ParameterlessMethod),
@@ -118,7 +128,7 @@ class IdTests
             methodName,
             BindingFlags.Instance | BindingFlags.NonPublic
         );
-        
+
         var actualFullName = IdFunctions.CreateFullName(method);
 
         Assert.That(actualFullName, Is.EqualTo(expectedFullName));
@@ -139,6 +149,28 @@ class IdTests
                 ".GenericMethodOfGenericClass[V](" +
                     "System.Collections.Generic.List`1[T]," +
                     "System.Collections.Generic.List`1[V]" +
+                ")"
+        ));
+    }
+
+    [Test]
+    public void TestFullNameFromConstructedGenericMethodOfNestedConstructedGenericClass()
+    {
+        var method = typeof(MyClass<MyClass>).GetMethod(
+            nameof(MyClass<int>.GenericMethodOfGenericClass),
+            BindingFlags.Instance | BindingFlags.NonPublic
+        ).MakeGenericMethod(typeof(MyClass));
+
+        var actualFullName = IdFunctions.CreateFullName(method);
+
+        Assert.That(actualFullName, Is.EqualTo(
+            "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[" +
+                "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]" +
+                ".GenericMethodOfGenericClass[" +
+                    "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
+                "](" +
+                    "System.Collections.Generic.List`1[Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]," +
+                    "System.Collections.Generic.List`1[Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]" +
                 ")"
         ));
     }

--- a/Allure.Net.Commons/Functions/IdFunctions.cs
+++ b/Allure.Net.Commons/Functions/IdFunctions.cs
@@ -147,11 +147,8 @@ public static class IdFunctions
 
     static string GetUniqueTypeName(Type type) =>
         IsSystemType(type)
-            ? ResolveFullName(type)
+            ? ConstructFullName(type)
             : GetTypeNameWithAssembly(type);
-
-    static string ResolveFullName(Type type) =>
-        type.FullName ?? ConstructFullName(type);
 
     static string ConstructFullName(Type type) =>
         type.DeclaringType is null
@@ -167,7 +164,7 @@ public static class IdFunctions
             : $"{type.Namespace}.{type.Name}";
 
     static string GetTypeNameWithAssembly(Type type) =>
-        $"{type.Assembly.GetName().Name}:" + ResolveFullName(type);
+        $"{type.Assembly.GetName().Name}:" + ConstructFullName(type);
 
     static bool IsSystemType(Type type) =>
         type.Assembly == systemTypesAssembly;


### PR DESCRIPTION
### Context
In some cases, assembly-qualified names are included in fullName values of NUnit test results, which leads to two problems:

1. The values become way too verbose (especially given that TestOps has a limit of 255 characters).
2. The values become dependent on assembly versions. For example, `int`'s assembly-qualified name includes the version of the target framework (e.g., `System.Int32, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e`). That means, this name changes each time the tests are compiled against a new version of .NET.

An example of a context where such an issue occurs is a test with a parameter of a generic type:

#### Example

Given the following test:

```csharp
using System.Collections.Generic;
using Allure.NUnit;
using NUnit.Framework;

[AllureNUnit]
public class MyTests
{
    [TestCaseSource(nameof(Parameters))]
    public void Foo(List<string> bar)
    {

    }

    public static IEnumerable<List<string>> Parameters => [ [ "Lorem", "Ipsum" ] ];
}
```

When run, the result of such a test will receive the following `fullName`:

```
MyAssembly:MyTests.Foo(System.Collections.Generic.List`1[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]][System.String])
```

Here, the `[[System.String, System.Private.CoreLib, Version=8.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]` part is both framework-dependent (`Version=8.0.0.0` of `System.Private.CoreLib` corresponds to .NET 8.0) and redundant (it follows by a more compact yet sufficient name of the type, `System.String`).

### Solution

The reason this behavior occurs is that we use `System.Type.FullName` when calculating full names. This PR precludes it.

Fixes #418.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
