### PR TITLE
fix(commons): use method type parameters in fullNames instead of arguments

### DIFF
--- a/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
@@ -157,7 +157,7 @@ class IdTests
     public void TestFullNameFromConstructedGenericMethodOfNestedConstructedGenericClass()
     {
         var method = typeof(MyClass<MyClass>).GetMethod(
-            nameof(MyClass<int>.GenericMethodOfGenericClass),
+            nameof(MyClass<MyClass>.GenericMethodOfGenericClass),
             BindingFlags.Instance | BindingFlags.NonPublic
         ).MakeGenericMethod(typeof(MyClass));
 
@@ -166,11 +166,9 @@ class IdTests
         Assert.That(actualFullName, Is.EqualTo(
             "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[" +
                 "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]" +
-                ".GenericMethodOfGenericClass[" +
-                    "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
-                "](" +
+                ".GenericMethodOfGenericClass[V](" +
                     "System.Collections.Generic.List`1[Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]," +
-                    "System.Collections.Generic.List`1[Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]" +
+                    "System.Collections.Generic.List`1[V]" +
                 ")"
         ));
     }

--- a/Allure.Net.Commons/Functions/IdFunctions.cs
+++ b/Allure.Net.Commons/Functions/IdFunctions.cs
@@ -32,24 +32,29 @@ public static class IdFunctions
     /// <summary>
     /// Creates a string that unuquely identifies a given method.
     /// </summary>
+    /// <param name="method">
+    /// A method.
+    /// If it's a constructed generic method, its generic definition is used instead.
+    /// </param>
     /// <remarks>
     /// For a given test method the full name includes:
     /// <list type="bullet">
-    /// <item>
-    /// fully-qualified name of the declaring type (including type parameters)
-    /// </item>
-    /// <item>name of the method</item>
-    /// <item>generic parameters of the method</item>
-    /// <item>
-    /// fully-qualified names of the parameter types, (including parameter
-    /// modifiers, if any)
-    /// </item>
+    /// <item>assembly name</item>
+    /// <item>namespace (if any)</item>
+    /// <item>name of type (including its declaring types, if any)</item>
+    /// <item>type parameters of the declaring type (for generic type definitions)</item>
+    /// <item>type arguments of the declaring type (for constructed generic types)</item>
+    /// <item>type parameters of the method (if any)</item>
+    /// <item>parameter types</item>
     /// </list>
-    /// A fully-qualified name of a type includes the assembly name, the
-    /// namespace and the class name (can be a nested class).
     /// </remarks>
-    public static string CreateFullName(MethodBase method)
+    public static string CreateFullName(MethodInfo method)
     {
+        if (method.IsGenericMethod && !method.IsGenericMethodDefinition)
+        {
+            method = method.GetGenericMethodDefinition();
+        }
+
         var className = SerializeType(method.DeclaringType);
         var methodName = method.Name;
         var typeParameters = method.GetGenericArguments();


### PR DESCRIPTION
### Context
Both NUnit and xUnit allow for generic test methods:

```csharp
public class TestClass
{
    [TestCase(1)] // T is System.Int32
    [TestCase("a")] // T is System.String
    public void TestMethod<T>(T arg)
    {
        /// ...
    }
}
```

Currently, Allure NUnit and Allure xUnit.net include the type argument (i.e., `System.Int32` or `System.String`) in `fullName`.

#### Mapping issues

Having `fullName` depending on method type arguments leads to a single test method having different `fullName` (and, consequently, `testCaseId`) values depending on the types of its arguments. That maps different argument sets of the test method into separate test cases in TestOps, rather than a single test case that encompasses all argument sets.

Additionally, this makes the selective run feature trickier to use, as all combinations of argument types need to be known in advance.

Those issues become more annoying in case the argument types can change across runs, e.g., if the values are provided from the outside.

While not significantly affecting Allure 2, these issues will become apparent in Allure 3, where plans are underway to rework how parameterized tests are reported.

#### `fullName` size issue

In most cases, type arguments are much more verbose than their corresponding type parameters. Some examples:

|Constructed method|Type parameter|Type argument|
|---|---|---|
|TestClass.TestMethod(1)|`T`|`System.Int32`|
|TestClass.TestMethod("a")|`T`|`System.String`|
|TestClass.TestMethod(new List<string>())|`T`|``System.Collections.Generic.List`1[System.String]``|
|TestClass.TestMethod(new MyClass())|`T`|`MyAssemblyName:MyNamespace.MyClass`|

### The proposal

This PR changes the `fullName` calculation to be based on generic method definitions instead of constructed generic methods. That replaces all method type arguments with their parameters in `fullName`.

> [!NOTE]
> Only method type arguments are replaced with their parameters. If the method is defined in a generic type, the `fullName` continues including the type arguments of that type. That's because multiple instantiations of the generic type create practically different types with different methods that must each correspond to its own test case.
> That said, defining test methods in a generic test class is a niche use unique to NUnit. xUnit doesn't support parameterization at the class level and thus doesn't support generic test classes.

The fix doesn't affect non-generic methods.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
