### PR TITLE
feat(nunit, xunit, specflow, reqnroll): titlePath

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -138,7 +138,11 @@ namespace Allure.NUnit.Core
         static IEnumerable<string> EnumerateNamesFromTestFixtureToRoot(ITest test)
         {
             for (ITest suite = GetTestFixture(test); suite is not null; suite = suite.Parent)
-                yield return suite.Name;
+                yield return suite switch
+                {
+                    TestAssembly a => a.Assembly?.GetName()?.Name ?? a.Name,
+                    _ => suite.Name,
+                };
         }
 
         TestResultContainer CreateTestContainer() =>

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using Allure.Net.Commons;
@@ -96,6 +95,7 @@ namespace Allure.NUnit.Core
             var testResult = new TestResult
             {
                 name = test.Name,
+                titlePath = EnumerateNamesFromTestFixtureToRoot(test).Reverse().ToList(),
                 labels = new List<Label>
                 {
                     Label.Thread(),
@@ -133,6 +133,12 @@ namespace Allure.NUnit.Core
                 TestStatus.Failed => Status.failed,
                 _ => Status.none
             };
+        }
+
+        static IEnumerable<string> EnumerateNamesFromTestFixtureToRoot(ITest test)
+        {
+            for (ITest suite = GetTestFixture(test); suite is not null; suite = suite.Parent)
+                yield return suite.Name;
         }
 
         TestResultContainer CreateTestContainer() =>
@@ -236,17 +242,17 @@ namespace Allure.NUnit.Core
         static TestFixture GetTestFixture(ITest test)
         {
             var currentTest = test;
-    
+
             while (currentTest != null)
             {
                 if (currentTest is TestFixture testFixture)
                 {
                     return testFixture;
                 }
-        
+
                 currentTest = currentTest.Parent;
             }
-            
+
             throw new InvalidOperationException(
                 $"Could not find TestFixture in the hierarchy for test: {test.FullName}. " +
                 $"Test type: {test.GetType().Name}"

--- a/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
@@ -84,13 +84,13 @@ class IdTests
     [TestCase(
         nameof(MyClass.ParameterlessMethod),
         "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass.ParameterlessMethod()",
-        TestName = "ParameterlessMethod"
+        TestName = "FullNameOfParameterlessMethod"
     )]
     [TestCase(
         nameof(MyClass.MethodWithParameterOfBuiltInType),
         "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
             ".MethodWithParameterOfBuiltInType(System.Int32)",
-        TestName = "MethodWithParameterOfBuiltInType"
+        TestName = "FullNameOfMethodWithParameterOfBuiltInType"
     )]
     [TestCase(
         nameof(MyClass.MethodWithParameterOfUserType),
@@ -98,7 +98,7 @@ class IdTests
             ".MethodWithParameterOfUserType(" +
                 "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
             ")",
-        TestName = "MethodWithParameterOfUserType"
+        TestName = "FullNameOfMethodWithParameterOfUserType"
     )]
     [TestCase(
         nameof(MyClass.MethodWithTwoParameters),
@@ -107,25 +107,25 @@ class IdTests
                 "System.Int32," +
                 "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
             ")",
-        TestName = "MethodWithTwoParameters"
+        TestName = "FullNameOfMethodWithTwoParameters"
     )]
     [TestCase(
         nameof(MyClass.MethodWithRefParameter),
         "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
             ".MethodWithRefParameter(System.Int32&)",
-        TestName = "MethodWithRefParameter"
+        TestName = "FullNameOfMethodWithRefParameter"
     )]
     [TestCase(
         nameof(MyClass.MethodWithGenericParameter),
         "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
             ".MethodWithGenericParameter[T]()",
-        TestName = "MethodWithGenericParameter"
+        TestName = "FullNameOfMethodWithGenericParameter"
     )]
     [TestCase(
         nameof(MyClass.MethodWithArgumentOfGenericType),
         "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass" +
             ".MethodWithArgumentOfGenericType[T](T)",
-        TestName = "MethodWithArgumentOfGenericType"
+        TestName = "FullNameOfMethodWithArgumentOfGenericType"
     )]
     [TestCase(
         nameof(MyClass.MethodWithArgumentOfTypeParametrizedByGenericType),
@@ -133,7 +133,7 @@ class IdTests
             ".MethodWithArgumentOfTypeParametrizedByGenericType[T](" +
                 "System.Collections.Generic.Dictionary`2[System.Int32,T]" +
             ")",
-        TestName = "MethodWithArgumentOfTypeParametrizedByGenericType"
+        TestName = "FullNameOfMethodWithArgumentOfTypeParametrizedByGenericType"
     )]
     [TestCase(
         nameof(MyClass.MethodWithArgumentOfGenericUserType),
@@ -141,7 +141,7 @@ class IdTests
             ".MethodWithArgumentOfGenericUserType[T](" +
                 "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[T]" +
             ")",
-        TestName = "MethodWithArgumentOfGenericUserType"
+        TestName = "FullNameOfMethodWithArgumentOfGenericUserType"
     )]
     public void FullNameFromMethod(string methodName, string expectedFullName)
     {

--- a/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
@@ -20,17 +20,38 @@ class IdTests
         );
     }
 
-    [TestCase(typeof(IdTests), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests")]
-    [TestCase(typeof(ClassWithoutNamespace), "Allure.Net.Commons.Tests:ClassWithoutNamespace")]
-    [TestCase(typeof(MyClass), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass")]
-    [TestCase(typeof(MyClass<>), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[T]")]
-    [TestCase(typeof(MyClass<string>), "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[System.String]")]
+    [TestCase(
+        typeof(IdTests),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests",
+        TestName = "FullNameOfNonGenericClass"
+    )]
+    [TestCase(
+        typeof(ClassWithoutNamespace),
+        "Allure.Net.Commons.Tests:ClassWithoutNamespace",
+        TestName = "FullNameOfClassWithNoNamespace"
+    )]
+    [TestCase(
+        typeof(MyClass),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass",
+        TestName = "FullNameOfNestedClass"
+    )]
+    [TestCase(
+        typeof(MyClass<>),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[T]",
+        TestName = "FullNameOfNestedGenericClassDefinition"
+    )]
+    [TestCase(
+        typeof(MyClass<string>),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[System.String]",
+        TestName = "FullNameOfNestedConstructedGenericClass"
+    )]
     [TestCase(
         typeof(MyClass<MyClass<string, int>, MyClass<MyClass>>),
         "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`2[" +
             "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`2[System.String,System.Int32]," +
             "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1[" +
-                "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]]"
+                "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]]",
+        TestName = "FullNameOfComplexConstructedGenericClass"
     )]
     public void TestFullNameFromClass(Type targetClass, string expectedFullName)
     {

--- a/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
@@ -53,6 +53,16 @@ class IdTests
                 "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass]]",
         TestName = "FullNameOfComplexConstructedGenericClass"
     )]
+    [TestCase(
+        typeof(MyClass<>.Nested),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1+Nested[T]",
+        TestName = "FullNameOfNestedClassOfGenericClassDefinition"
+    )]
+    [TestCase(
+        typeof(MyClass<int>.Nested),
+        "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.IdTests+MyClass`1+Nested[System.Int32]",
+        TestName = "FullNameOfNestedClassOfConstructedGenericClass"
+    )]
     public void TestFullNameFromClass(Type targetClass, string expectedFullName)
     {
         Assert.That(
@@ -76,6 +86,7 @@ class IdTests
 
     class MyClass<T>
     {
+        public class Nested { }
         internal void GenericMethodOfGenericClass<V>(List<T> _, List<V> __) { }
     }
 

--- a/Allure.Net.Commons.Tests/FunctionTests/TitlePathTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/TitlePathTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using Allure.Net.Commons.Functions;
+using NUnit.Framework;
+
+namespace Allure.Net.Commons.Tests.FunctionTests;
+
+class TitlePathTests
+{
+    [TestCase(
+        typeof(TitlePathTests),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests",
+        TestName = "Outmost type with namespave"
+    )]
+    [TestCase(
+        typeof(ClassWithoutNamespace),
+        "Allure.Net.Commons.Tests",
+        "ClassWithoutNamespace",
+        TestName = "Outmost type no namespace"
+    )]
+    [TestCase(
+        typeof(MyClass),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass",
+        TestName = "Nested class"
+    )]
+    [TestCase(
+        typeof(MyClass<>),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass`1[T]",
+        TestName = "Nested generic class definition"
+    )]
+    [TestCase(
+        typeof(MyClass<string>),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass`1[System.String]",
+        TestName = "Nested constructed generic class - system type alias"
+    )]
+    [TestCase(
+        typeof(MyClass<DateTime>),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass`1[System.DateTime]",
+        TestName = "Nested constructed generic class - system type"
+    )]
+    [TestCase(
+        typeof(MyClass<ClassWithoutNamespace>),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass`1[Allure.Net.Commons.Tests:ClassWithoutNamespace]",
+        TestName = "Nested constructed generic class - custom type"
+    )]
+    [TestCase(
+        typeof(MyClass<MyClass<string, int>, MyClass<MyClass>>),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass`2[" +
+            "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.TitlePathTests+MyClass`2[System.String,System.Int32]," +
+            "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.TitlePathTests+MyClass`1[" +
+                "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.TitlePathTests+MyClass]]",
+        TestName = "Nested constructed generic class - complex"
+    )]
+    public void TestTitlePathByClass(Type targetClass, params string[] expectedTitlePath)
+    {
+        Assert.That(
+            IdFunctions.CreateTitlePath(targetClass),
+            Is.EqualTo(expectedTitlePath)
+        );
+    }
+
+    class MyClass
+    {
+        internal void ParameterlessMethod() { }
+        internal void MethodWithParameterOfBuiltInType(int _) { }
+        internal void MethodWithParameterOfUserType(MyClass _) { }
+        internal void MethodWithTwoParameters(int _, MyClass __) { }
+        internal void MethodWithRefParameter(ref int _) { }
+        internal void MethodWithGenericParameter<T>() { }
+        internal void MethodWithArgumentOfGenericType<T>(T _) { }
+        internal void MethodWithArgumentOfTypeParametrizedByGenericType<T>(Dictionary<int, T> _) { }
+        internal void MethodWithArgumentOfGenericUserType<T>(MyClass<T> _) { }
+    }
+
+    class MyClass<T>
+    {
+        public class Nested<G> { }
+        internal void GenericMethodOfGenericClass<V>(List<T> _, List<V> __) { }
+    }
+
+    class MyClass<T1, T2> { }
+}

--- a/Allure.Net.Commons/Functions/IdFunctions.cs
+++ b/Allure.Net.Commons/Functions/IdFunctions.cs
@@ -18,6 +18,42 @@ public static class IdFunctions
     public static string CreateUUID() => Guid.NewGuid().ToString();
 
     /// <summary>
+    /// Creates a titlePath: a path to a test class in a tree of test results.
+    /// </summary>
+    /// <param name="type">A type representing a test class</param>
+    /// <remarks>
+    /// A titlePath consists of:
+    /// <list type="bullet">
+    /// <item>assembly name</item>
+    /// <item>elements of namespace</item>
+    /// <item>name of type (including its declaring types, if any)</item>
+    /// <item>type parameters (for generic type definitions)</item>
+    /// <item>type arguments (for constructed generic types)</item>
+    /// </list>
+    /// </remarks>
+    public static List<string> CreateTitlePath(Type type)
+    {
+        static IEnumerable<string> ExpandNestness(Type type)
+        {
+            for (; type.IsNested; type = type.DeclaringType)
+                yield return type.Name;
+            yield return type.Name;
+        }
+
+        var assemblyName = type.Assembly.GetName().Name;
+        var namespaceParts = (type.Namespace ?? "").Split('.').Where(s => s.Length > 0);
+        var typeName = string.Join("+", ExpandNestness(type).Reverse());
+        var typeArguments = type.GetGenericArguments();
+        var typeArgumentsText = SerializeTypeParameterTypeList(typeArguments);
+
+        return [
+            assemblyName,
+            .. namespaceParts,
+            typeName + typeArgumentsText,
+        ];
+    }
+
+    /// <summary>
     /// Creates a name that uniquely identifies a given type.
     /// </summary>
     /// <remarks>

--- a/Allure.Net.Commons/Model/allure2.Designer.cs
+++ b/Allure.Net.Commons/Model/allure2.Designer.cs
@@ -609,6 +609,8 @@ namespace Allure.Net.Commons
 
         private string _rerunOf;
 
+        private List<string> _titlePath;
+
         private string _fullName;
 
         private List<Label> _labels;
@@ -618,6 +620,7 @@ namespace Allure.Net.Commons
 
         public TestResult()
         {
+            this._titlePath = new List<string>();
             this._links = new List<Link>();
             this._labels = new List<Label>();
         }
@@ -667,6 +670,18 @@ namespace Allure.Net.Commons
             set
             {
                 this._rerunOf = value;
+            }
+        }
+
+        public List<string> titlePath
+        {
+            get
+            {
+                return this._titlePath;
+            }
+            set
+            {
+                this._titlePath = value;
             }
         }
 

--- a/Allure.Net.Commons/Model/allure2.xsd
+++ b/Allure.Net.Commons/Model/allure2.xsd
@@ -55,6 +55,7 @@
 
                     <xsd:element name="rerunOf" type="xsd:string"/>
 
+                    <xsd:element name="titlePath" type="ns:Ids"/>
                     <xsd:element name="fullName" type="xsd:string"/>
                     <xsd:element name="labels" type="ns:Labels" minOccurs="0"/>
                     <xsd:element name="links" type="ns:Links" minOccurs="0"/>

--- a/Allure.Reqnroll/Functions/MappingFunctions.cs
+++ b/Allure.Reqnroll/Functions/MappingFunctions.cs
@@ -305,6 +305,7 @@ static class MappingFunctions
         new()
         {
             uuid = IdFunctions.CreateUUID(),
+            titlePath = CreateTitlePath(featureAssembly, featureInfo),
             fullName = CreateFullName(
                 featureAssembly,
                 featureInfo,
@@ -377,6 +378,20 @@ static class MappingFunctions
         sw.Flush();
         return ms.ToArray();
     }
+
+    internal static List<string> CreateTitlePath(
+        Assembly featureAssembly,
+        FeatureInfo featureInfo
+    ) => [
+        featureAssembly.GetName().Name,
+        ..featureInfo.FolderPath.Split(
+            Path.DirectorySeparatorChar,
+            Path.AltDirectorySeparatorChar
+        ).Where((v) => !string.IsNullOrEmpty(v)),
+        string.IsNullOrEmpty(featureInfo.Title)
+            ? "Feature"
+            : featureInfo.Title,
+    ];
 
     static bool TreatAsVerticalArgumentTable(
         IReadOnlyList<string> header,

--- a/Allure.SpecFlow/PluginHelper.cs
+++ b/Allure.SpecFlow/PluginHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -93,6 +94,7 @@ namespace Allure.SpecFlowPlugin
             {
                 name = title,
                 description = scenarioInfo.Description,
+                titlePath = CreateTitlePath(testRunnerManager, featureInfo),
                 labels = new List<Label>
                 {
                     Label.Thread(),
@@ -289,6 +291,20 @@ namespace Allure.SpecFlowPlugin
             testResult.historyId = scenarioTitle + parametersHash;
             testResult.fullName = scenarioTitle;
         }
+
+        static List<string> CreateTitlePath(
+            ITestRunnerManager testRunnerManager,
+            FeatureInfo featureInfo
+        ) => [
+            testRunnerManager.TestAssembly.GetName().Name,
+            ..featureInfo.FolderPath.Split(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar
+            ).Where(v => !string.IsNullOrEmpty(v)),
+            string.IsNullOrEmpty(featureInfo.Title)
+                ? "Feature"
+                : featureInfo.Title,
+        ];
 
         static string CreateFullName(
             ITestRunnerManager testRunnerManager,

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -128,9 +128,11 @@ namespace Allure.Xunit
         )
         {
             var testMethod = testCase.TestMethod;
+            var testClass = testMethod.TestClass.Class.ToRuntimeType();
             var testResult = new TestResult
             {
                 name = BuildName(testCase),
+                titlePath = IdFunctions.CreateTitlePath(testClass),
                 labels = new()
                 {
                     Label.Thread(),


### PR DESCRIPTION
## Context
This PR adds a new property called `titlePath` to `TestResult` and makes Allure NUnit, Allure xUnit.net, Allure SpecFlow, and Allure.Reqnroll fill it.

More about `titlePath`: allure-framework/allure-js#1260.

### NUnit

For an NUnit test, the `titlePath` follows the NUnit `ITest` hierarchy. Only nodes at the `TestSuite` level or higher are translated into `titlePath`.

#### Example:

Given a test assembly called `MyTestAssembly` and the following code:

```csharp
using NUnit.Framework;

namespace Foo.Bar;

class Baz
{
    [Test]
    public void Qux() { }

    [TestCase(1)]
    public void Qut(int _) { }
}
```

The `titlePath` of both tests will be as follows:

```js
[
  "MyTestAssembly", // the assembly name
  "Foo",  // the namespace
  "Bar", // the namespace
  "Baz", // the test class
]
```

The test class part can be renamed from code via the `TestFixture.TestName` property.

### xUnit.net

For xUnit.net tests, the `titlePath` is defined by the tests' declaring type (a test class). It contains the assembly name, namespace elements, and the class name.

### Reqnroll and SpecFlow

For Reqnroll and SpecFlow tests, the `titlePath` contains the assembly name, the parent directories of the feature file inside the assembly, and the feature name. If the feature is nameless, the `Feature` placeholder is used instead.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
