### PR TITLE
feat(commons): don't emit empty `*-container.json` files

### DIFF
--- a/Allure.Net.Commons.Tests/AllureLifeCycleTest.cs
+++ b/Allure.Net.Commons.Tests/AllureLifeCycleTest.cs
@@ -227,5 +227,48 @@ namespace Allure.Net.Commons.Tests
             Assert.That(lifecycle.Context.CurrentTest.historyId, Is.EqualTo("history-id"));
             Assert.That(lifecycle.Context.CurrentTest.testCaseId, Is.EqualTo("testcase-id"));
         }
+
+        [Test]
+        public void EmptyTestContainerNotWritten()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(_ => writer);
+            lifecycle.StartTestContainer(new() { uuid = "foo" });
+            lifecycle.StopTestContainer();
+
+            lifecycle.WriteTestContainer();
+
+            Assert.That(writer.testContainers, Is.Empty);
+        }
+
+        [Test]
+        public void ContainerWithBeforeFixtureIsWritten()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(_ => writer);
+            lifecycle.StartTestContainer(new() { uuid = "foo" });
+            lifecycle.StartBeforeFixture(new());
+            lifecycle.StopFixture();
+            lifecycle.StopTestContainer();
+
+            lifecycle.WriteTestContainer();
+
+            Assert.That(writer.testContainers, Has.One.Items);
+        }
+
+        [Test]
+        public void ContainerWithAfterFixtureIsWritten()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(_ => writer);
+            lifecycle.StartTestContainer(new() { uuid = "foo" });
+            lifecycle.StartAfterFixture(new());
+            lifecycle.StopFixture();
+            lifecycle.StopTestContainer();
+
+            lifecycle.WriteTestContainer();
+
+            Assert.That(writer.testContainers, Has.One.Items);
+        }
     }
 }

--- a/Allure.Net.Commons/AllureLifecycle.cs
+++ b/Allure.Net.Commons/AllureLifecycle.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using Allure.Net.Commons.Configuration;
 using Allure.Net.Commons.Functions;
@@ -264,7 +265,10 @@ public class AllureLifecycle
     {
         var container = this.Context.CurrentContainer;
         this.UpdateContext(c => c.WithNoLastContainer());
-        this.writer.Write(container);
+        if (container.befores.Any() || container.afters.Any())
+        {
+            this.writer.Write(container);
+        }
         return this;
     }
 


### PR DESCRIPTION
### Context

The PR changes AllureLifecycle to only write a container if it has at least one fixture of any type. This may drastically reduce the number of container files written to disk in some cases, especially if there are many tests that don't use test-scoped setup/teardown.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
