### PR TITLE
fix(nunit, xunit): exclude redundant data from display names and testMethod

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -94,7 +94,7 @@ namespace Allure.NUnit.Core
         {
             var testResult = new TestResult
             {
-                name = test.Name,
+                name = ResolveDisplayName(test),
                 titlePath = EnumerateNamesFromTestFixtureToRoot(test).Reverse().ToList(),
                 labels = new List<Label>
                 {
@@ -134,6 +134,13 @@ namespace Allure.NUnit.Core
                 _ => Status.none
             };
         }
+
+        static string ResolveDisplayName(ITest test) =>
+            test.Parent switch
+            {
+                ParameterizedMethodSuite suite => suite.Name,
+                _ => test.Name,
+            };
 
         static IEnumerable<string> EnumerateNamesFromTestFixtureToRoot(ITest test)
         {

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -331,11 +331,13 @@ namespace Allure.Xunit
             string.Concat(Guid.NewGuid().ToString(), "-", name);
 
         static string BuildName(ITestCase testCase) =>
-            testCase.TestMethod.Method.GetCustomAttributes(
+            MaybeGetExplicitDisplayName(testCase.TestMethod.Method)
+                ?? testCase.TestMethod.Method.Name;
+
+        static string? MaybeGetExplicitDisplayName(IMethodInfo method) =>
+            method.GetCustomAttributes(
                 typeof(FactAttribute)
-            ).SingleOrDefault()?.GetNamedArgument<string>(
-                "DisplayName"
-            ) ?? BuildFullName(testCase);
+            ).SingleOrDefault()?.GetNamedArgument<string>("DisplayName");
 
         static string BuildFullName(ITestCase testCase)
         {

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -140,7 +140,7 @@ namespace Allure.Xunit
                     Label.Language(),
                     Label.Framework("xUnit.net"),
                     Label.TestClass(testMethod.TestClass.Class.Name),
-                    Label.TestMethod(displayName),
+                    Label.TestMethod(testCase.TestMethod.Method.Name),
                     Label.Package(testMethod.TestClass.Class.Name),
                 }
             };


### PR DESCRIPTION
### Context

Currently, the default test names assigned by `Allure.Xunit` have the following format: `<namespace>.<class>.<method>(<parameters>)` (the same format is used for full names if `useLegacyId` is set to `true`):

<img width="760" height="284" alt="image" src="https://github.com/user-attachments/assets/2701625a-ecdd-42dd-9ea2-078f81aee537" />

This leads to redundant data being included in a test's name:

  - namespace and class: already included in `titlePath` and `package`
  - parameters: visible next to test names in Allure 2; will be improved in Allure 3

The same is also true for Allure.Xunit's `testMethod` values (it's used instead of display names on the `Packages` tab). These values additionally include test arguments (the actual values used during the test execution), which are redundant for the same reason the parameters are redundant in display names.

The only motivation I can think of for having such detailed names is to create a somewhat manageable report, in case no hierarchy is properly defined. As we at least have the `packages` hierarchy, which contains the namespaces and the class names, the redundant data can be excluded from the names.

Similarly, `Allure.NUnit` uses the following format: `<method>.(<arguments>)`, where `arguments` are redundant for the same reason as `parameters` are redundant for Allure.Xunit:

<img width="758" height="332" alt="image" src="https://github.com/user-attachments/assets/a6e97c63-5f79-47bf-9542-64b574f6883d" />

Additionally, having argument-dependent names doesn't play well with TestOps, as one of these argument-specific names will be picked up by the parameterized test case, which is confusing.

The PR shortens the default names to only include method names.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
