### PR TITLE
feat(nunit): include class names in packages

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -102,9 +102,7 @@ namespace Allure.NUnit.Core
                     Label.Host(),
                     Label.Language(),
                     Label.Framework("NUnit 3"),
-                    Label.Package(
-                        GetNamespace(test.ClassName)
-                    ),
+                    Label.Package(test.ClassName),
                     Label.TestMethod(test.MethodName),
                     Label.TestClass(
                         GetClassName(test.ClassName)


### PR DESCRIPTION
### Context
Currently, Allure.NUnit doesn't include test class names in `package` label values. This leads to having method names directly under their namespaces on a "Packages" tab.

The PR adds class names to the package hierarchy to make it more useful out of the box.
