### PR TITLE
feat(nunit, xunit): set the default suites hierarchy for test results

### DIFF
--- a/Allure.NUnit/Attributes/AllureDisplayIgnoredAttribute.cs
+++ b/Allure.NUnit/Attributes/AllureDisplayIgnoredAttribute.cs
@@ -84,6 +84,9 @@ namespace Allure.NUnit.Attributes
             this.ApplyLegacySuiteLabels(testResult, reason);
 
             AllureLifecycle.Instance.StartTestCase(testResult);
+
+            AllureNUnitHelper.ApplyDefaultSuiteHierarchy(test);
+
             AllureLifecycle.Instance.StopTestCase();
             AllureLifecycle.Instance.WriteTestCase();
         }

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -58,6 +58,7 @@ namespace Allure.NUnit.Core
         internal void StopTestCase()
         {
             UpdateTestDataFromNUnitProperties();
+            ApplyDefaultSuiteHierarchy(_test);
             AddConsoleOutputAttachment();
 
             var result = TestContext.CurrentContext.Result;
@@ -260,6 +261,23 @@ namespace Allure.NUnit.Core
             throw new InvalidOperationException(
                 $"Could not find TestFixture in the hierarchy for test: {test.FullName}. " +
                 $"Test type: {test.GetType().Name}"
+            );
+        }
+
+        internal static void ApplyDefaultSuiteHierarchy(ITest test)
+        {
+            var testClassFullName = test.ClassName;
+            var assemblyName = test.TypeInfo?.Assembly?.GetName().Name;
+            var @namespace = GetNamespace(testClassFullName);
+            var className = GetClassName(testClassFullName);
+
+            AllureLifecycle.UpdateTestCase(
+                testResult => ModelFunctions.EnsureSuites(
+                    testResult,
+                    assemblyName,
+                    @namespace,
+                    className
+                )
             );
         }
 

--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -225,7 +225,7 @@ namespace Allure.NUnit.Core
 
         static string GetNamespace(string classFullName)
         {
-            var lastDotIndex = classFullName?.LastIndexOf('.') ?? -1;
+            var lastDotIndex = StripTypeArgs(classFullName)?.LastIndexOf('.') ?? -1;
             return lastDotIndex == -1
                 ? null
                 : classFullName.Substring(
@@ -236,12 +236,20 @@ namespace Allure.NUnit.Core
 
         static string GetClassName(string classFullName)
         {
-            var lastDotIndex = classFullName?.LastIndexOf('.') ?? -1;
+            var lastDotIndex = StripTypeArgs(classFullName)?.LastIndexOf('.') ?? -1;
             return lastDotIndex == -1
                 ? classFullName
                 : classFullName.Substring(
                     lastDotIndex + 1
                 );
+        }
+
+        static string StripTypeArgs(string classFullName)
+        {
+            var typeArgsStart = classFullName?.IndexOf('<') ?? -1;
+            return typeArgsStart == -1
+                ? classFullName
+                : classFullName.Substring(0, typeArgsStart);
         }
 
         static TestFixture GetTestFixture(ITest test)
@@ -266,7 +274,7 @@ namespace Allure.NUnit.Core
 
         internal static void ApplyDefaultSuiteHierarchy(ITest test)
         {
-            var testClassFullName = test.ClassName;
+            var testClassFullName = GetTestFixture(test).FullName;
             var assemblyName = test.TypeInfo?.Assembly?.GetName().Name;
             var @namespace = GetNamespace(testClassFullName);
             var className = GetClassName(testClassFullName);

--- a/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/DefaultSuiteTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/DefaultSuiteTests.cs
@@ -1,0 +1,102 @@
+using NUnit.Framework;
+using Allure.Net.Commons.Functions;
+
+namespace Allure.Net.Commons.Tests.FunctionTests.ModelFunctionTests;
+
+class DefaultSuiteTests
+{
+    [Test]
+    public void DefaultSuiteLabelsAdded()
+    {
+        TestResult testResult = new() { labels = [] };
+
+        ModelFunctions.EnsureSuites(testResult, "foo", "bar", "baz");
+
+        Assert.That(
+            testResult.labels,
+            Does.Contain(
+                Label.ParentSuite("foo")
+            ).UsingPropertiesComparer().And.Contains(
+                Label.Suite("bar")
+            ).UsingPropertiesComparer().And.Contains(
+                Label.SubSuite("baz")
+            ).UsingPropertiesComparer()
+        );
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void EmptyOrNullParentSuiteNotAdded(string parentSuite)
+    {
+        TestResult testResult = new() { labels = [] };
+
+        ModelFunctions.EnsureSuites(testResult, parentSuite, "bar", "baz");
+
+        Assert.That(
+            testResult.labels,
+            Has.Exactly(0).Matches<Label>(l => l.name == LabelName.PARENT_SUITE)
+                .And.Contains(
+                    Label.Suite("bar")
+                ).UsingPropertiesComparer().And.Contains(
+                    Label.SubSuite("baz")
+                ).UsingPropertiesComparer()
+        );
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void EmptyOrNullSuiteNotAdded(string suite)
+    {
+        TestResult testResult = new() { labels = [] };
+
+        ModelFunctions.EnsureSuites(testResult, "foo", suite, "baz");
+
+        Assert.That(
+            testResult.labels,
+            Does.Contain(
+                Label.ParentSuite("foo")
+            ).UsingPropertiesComparer()
+                .And.Exactly(0).Matches<Label>(l => l.name == LabelName.SUITE)
+                .And.Contains(
+                    Label.SubSuite("baz")
+                ).UsingPropertiesComparer()
+        );
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void EmptyOrNullSubSuiteNotAdded(string subSuite)
+    {
+        TestResult testResult = new() { labels = [] };
+
+        ModelFunctions.EnsureSuites(testResult, "foo", "bar", subSuite);
+
+        Assert.That(
+            testResult.labels,
+            Does.Contain(
+                Label.ParentSuite("foo")
+            ).UsingPropertiesComparer().And.Contains(
+                Label.Suite("bar")
+            ).UsingPropertiesComparer().And.Exactly(0).Matches<Label>(
+                l => l.name == LabelName.SUB_SUITE
+            )
+        );
+    }
+
+    [TestCase("parentSuite")]
+    [TestCase("suite")]
+    [TestCase("subSuite")]
+    public void DefaultSuiteLabelsNotAddedIfSuitesHierarchyDefined(string labelName)
+    {
+        TestResult testResult = new() { labels = [new() { name = labelName, value = "qux" }] };
+
+        ModelFunctions.EnsureSuites(testResult, "foo", "bar", "baz");
+
+        Assert.That(
+            testResult.labels,
+            Does.Not.Contain(Label.ParentSuite("foo")).UsingPropertiesComparer()
+                .And.Not.Contains(Label.Suite("bar")).UsingPropertiesComparer()
+                .And.Not.Contains(Label.SubSuite("baz")).UsingPropertiesComparer()
+        );
+    }
+}

--- a/Allure.Net.Commons/Functions/ModelFunctions.cs
+++ b/Allure.Net.Commons/Functions/ModelFunctions.cs
@@ -58,6 +58,60 @@ public static class ModelFunctions
                 trace = e.ToString()
             };
 
+    /// <summary>
+    /// Checks if the test result contains a suite-hierarchy label, i.e., one
+    /// of the <c>parentSuite</c>, <c>suite</c>, or <c>subSuite</c> labels. If
+    /// not, adds the provided default values to the list of labels. Otherwise,
+    /// leaves the test result as is.
+    /// </summary>
+    /// <param name="testResult">A test result to modify</param>
+    /// <param name="parentSuite">
+    /// A value for the <c>parentSuite</c> label. If null or empty, the label
+    /// won't be added
+    /// </param>
+    /// <param name="suite">
+    /// A value for the <c>suite</c> label. If null or empty, the label won't
+    /// be added
+    /// </param>
+    /// <param name="subSuite">
+    /// A value for the <c>subSuite</c> label. If null or empty, the label won't
+    /// be added
+    /// </param>
+    public static void EnsureSuites(
+        TestResult testResult,
+        string? parentSuite,
+        string? suite,
+        string? subSuite
+    )
+    {
+        var labels = testResult.labels;
+        if (labels.Any(IsSuiteLabel))
+        {
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(parentSuite))
+        {
+            labels.Add(Label.ParentSuite(parentSuite));
+        }
+
+        if (!string.IsNullOrEmpty(suite))
+        {
+            labels.Add(Label.Suite(suite));
+        }
+
+        if (!string.IsNullOrEmpty(subSuite))
+        {
+            labels.Add(Label.SubSuite(subSuite));
+        }
+    }
+
+    static bool IsSuiteLabel(Label label) => label.name switch
+    {
+        LabelName.PARENT_SUITE or LabelName.SUITE or LabelName.SUB_SUITE => true,
+        _ => false
+    };
+
     static IEnumerable<string> GetExceptionClassChain(Exception e)
     {
         for (var type = e.GetType(); type != null; type = type.BaseType)

--- a/Allure.Xunit/AllureMessageSink.cs
+++ b/Allure.Xunit/AllureMessageSink.cs
@@ -153,6 +153,7 @@ namespace Allure.Xunit
                 this.RunInTestContext(test, () =>
                 {
                     this.AddAllureParameters(test, testData.Arguments);
+                    AllureXunitHelper.ApplyDefaultSuites(test.TestCase.TestMethod);
                     AllureXunitHelper.ReportCurrentTestCase();
                     if (!IsStaticTestMethod(message))
                     {

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -99,6 +99,27 @@ namespace Allure.Xunit
             });
         }
 
+        internal static void ApplyDefaultSuites(ITestMethod method)
+        {
+            var testClass = method.TestClass.Class;
+            var runtimeType = testClass.ToRuntimeType();
+            var assemblyName = runtimeType?.Assembly?.GetName().Name;
+            var @namespace = runtimeType?.Namespace;
+            var className =
+                string.IsNullOrEmpty(@namespace)
+                    ? testClass.Name
+                    : testClass.Name?.Substring(@namespace.Length + 1);
+
+            AllureLifecycle.Instance.UpdateTestCase(
+                testResult => ModelFunctions.EnsureSuites(
+                    testResult,
+                    assemblyName,
+                    @namespace,
+                    className
+                )
+            );
+        }
+
         internal static void ReportCurrentTestCase()
         {
             AllureLifecycle.Instance.StopTestCase();


### PR DESCRIPTION
### Context

The PR implements the default suite hierarchy in Allure.NUnit and Allure.Xunit. See motivation in #364.

In NUnit, generic and parameterized classes are mapped to distinct sub suites.

If a test result already contains a suite hierarchy label (`parentSuite`, `suite`, or `subSuite`), the default labels are not added. This allows overwriting the default hierarchy with a custom one by using the Allure API (both runtime and attribute-based).

Closes #364.
