### PR TITLE
Support for Reqnroll v3

### DIFF
--- a/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
+++ b/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
@@ -15,9 +15,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
         <PackageReference Include="Castle.Core" Version="5.1.1" />
-        <PackageReference Include="Reqnroll" Version="2.4.1" />
-        <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="2.4.1" />
-        <PackageReference Include="Reqnroll.xUnit" Version="2.4.1" />
+        <PackageReference Include="Reqnroll" Version="3.0.3" />
+        <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.0.3" />
+        <PackageReference Include="Reqnroll.xUnit" Version="3.0.3" />
         <PackageReference Include="xunit" Version="2.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>

--- a/Allure.Reqnroll.Tests/Integration/IntegrationTests.cs
+++ b/Allure.Reqnroll.Tests/Integration/IntegrationTests.cs
@@ -274,12 +274,12 @@ class IntegrationTests
             {
                 var children = parser.Parse(f.FullName).Feature.Children.ToList();
                 var scenarioOutlines = children.Where(
-                    x => (x as dynamic).Examples.Length > 0
+                    x => (x as dynamic).Examples.Count > 0
                 ).ToList();
                 foreach (var s in scenarioOutlines)
                 {
                     var examplesCount = (s as dynamic).Examples[0]
-                        .TableBody.Length;
+                        .TableBody.Count;
                     for (int i = 1; i < examplesCount; i++)
                     {
                         children.Add(s);

--- a/Allure.Reqnroll/Allure.Reqnroll.csproj
+++ b/Allure.Reqnroll/Allure.Reqnroll.csproj
@@ -21,7 +21,7 @@
 
     <ItemGroup>
         <PackageReference Include="CsvHelper" Version="33.0.1" />
-        <PackageReference Include="Reqnroll" Version="2.4.1" />
+        <PackageReference Include="Reqnroll" Version="3.0.3" />
         <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
     </ItemGroup>
 

--- a/Allure.Reqnroll/Events/HookFinishedEventHandler.cs
+++ b/Allure.Reqnroll/Events/HookFinishedEventHandler.cs
@@ -52,8 +52,6 @@ internal class HookFinishedEventHandler : AllureReqnrollEventHandler<HookFinishe
                 AllureReqnrollStateFacade.StartTestCase();
                 break;
             case HookType.AfterScenario:
-                AllureReqnrollStateFacade.StopContainer();
-                break;
             case HookType.AfterFeature:
                 AllureReqnrollStateFacade.StopContainer();
                 this.EnsureFeatureReported(eventData);

--- a/Allure.Reqnroll/Events/HookFinishedEventHandler.cs
+++ b/Allure.Reqnroll/Events/HookFinishedEventHandler.cs
@@ -52,6 +52,8 @@ internal class HookFinishedEventHandler : AllureReqnrollEventHandler<HookFinishe
                 AllureReqnrollStateFacade.StartTestCase();
                 break;
             case HookType.AfterScenario:
+                AllureReqnrollStateFacade.StopContainer();
+                break;
             case HookType.AfterFeature:
                 AllureReqnrollStateFacade.StopContainer();
                 this.EnsureFeatureReported(eventData);

--- a/Allure.Reqnroll/SelectiveRun/TestPlanAwareTestRunner.cs
+++ b/Allure.Reqnroll/SelectiveRun/TestPlanAwareTestRunner.cs
@@ -44,9 +44,6 @@ class TestPlanAwareTestRunner : ITestRunner
         this.underlyingRunner = underlyingRunner;
     }
 
-    public void InitializeTestRunner(string testWorkerId) =>
-        this.underlyingRunner.InitializeTestRunner(testWorkerId);
-
     public async Task OnTestRunStartAsync() =>
         await this.underlyingRunner.OnTestRunStartAsync();
 
@@ -59,9 +56,9 @@ class TestPlanAwareTestRunner : ITestRunner
     public async Task OnFeatureEndAsync() =>
         await this.underlyingRunner.OnFeatureEndAsync();
 
-    public void OnScenarioInitialize(ScenarioInfo scenarioInfo)
+    public void OnScenarioInitialize(ScenarioInfo scenarioInfo, RuleInfo ruleInfo)
     {
-        this.underlyingRunner.OnScenarioInitialize(scenarioInfo);
+        this.underlyingRunner.OnScenarioInitialize(scenarioInfo, ruleInfo);
         this.ApplyTestPlanToCurrentScenario();
     }
 
@@ -74,7 +71,7 @@ class TestPlanAwareTestRunner : ITestRunner
         else
         {
             // This call will set the scenario's status to skipped.
-            this.SkipScenario();
+            await this.SkipScenarioAsync();
 
             // We're skipping scenarios not in the test plan using the unit
             // test framework's runtime API. Neither BeforeScenario nor
@@ -91,7 +88,7 @@ class TestPlanAwareTestRunner : ITestRunner
     public async Task OnScenarioEndAsync() =>
         await this.underlyingRunner.OnScenarioEndAsync();
 
-    public void SkipScenario() => this.underlyingRunner.SkipScenario();
+    public async Task SkipScenarioAsync() => await this.underlyingRunner.SkipScenarioAsync();
 
     public async Task GivenAsync(
         string text,


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter, and no dot is required at the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

Reqnroll has released a new major version - v3 - https://github.com/reqnroll/Reqnroll/blob/main/CHANGELOG.md#v300---2025-08-21.

The release brings some breaking changes. This leads to the need of the following amendments to the Allure-Reqnroll plugin:
- Reqnroll deprecates and removes synchronous versions of methods - `async` versions now should be used instead.
- `InitializeTestRunner()` is gone from the Reqnroll API.
- Reqnroll fixes some bugs in published events - which makes some workarounds applied in Allure unnecessary (in fact, they can't function together).

That is my first contribution to this codebase, so I hope I do not break conventions and best practices.

All unit and integration tests in Allure repo are made green - I also have a setup against our project's e2e tests ready for debugging. Let me know what you think and if any changes you would see necessary.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests - all fixed

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
