### PR TITLE
chore: fix pwsh environment variable syntax in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
         shell: pwsh
         run: |
           dotnet nuget push "${{ env.PACKAGE_OUTPUT_PATH }}/*.nupkg" `
-            -k ${NUGET_TOKEN} `
-            -s https://api.nuget.org/v3/index.json
+            --api-key "$Env:NUGET_TOKEN" `
+            --source "https://api.nuget.org/v3/index.json"
         env:
           NUGET_TOKEN: ${{ secrets.NUGET_TOKEN }}


### PR DESCRIPTION
### Context

#586 has changed the `publish` job (`publish.yml`) to be run on Windows. Consequently, the `run:` step syntax had to be changed from bash to pwsh.

This PR fixes the `NuGet publish` step to follow the pwsh syntax rules for environment variables.
