### PR TITLE
chore: fix directory separator in `dotnet nuget push` argument (publish.yml)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,7 +68,7 @@ jobs:
       - name: 'NuGet publish'
         shell: pwsh
         run: |
-          dotnet nuget push "${{ env.PACKAGE_OUTPUT_PATH }}/*.nupkg" `
+          dotnet nuget push "${{ env.PACKAGE_OUTPUT_PATH }}\*.nupkg" `
             --api-key "$Env:NUGET_TOKEN" `
             --source "https://api.nuget.org/v3/index.json"
         env:


### PR DESCRIPTION
### Context

Although Windows accepts `/` as directory separators in most cases, `dotnet nuget push` requires backslashes. Otherwise, it fails with "File does not exist".

This PR fixes the separator used in `publish.yml`.
