### PR TITLE
Make Allure.Xunit compatible with Allure.Reqnroll

### DIFF
--- a/Allure.Xunit/AllureMessageSink.cs
+++ b/Allure.Xunit/AllureMessageSink.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Linq;
 using Allure.Net.Commons;
 using Allure.Net.Commons.TestPlan;
@@ -73,6 +72,12 @@ namespace Allure.Xunit
         {
             var message = args.Message;
             var test = message.Test;
+
+            if (AllureXunitHelper.IsOnExternalAuthority(args.Message.Test))
+            {
+                return;
+            }
+
             var testData = this.GetOrCreateTestData(test);
 
             if (testData.IsSelected)
@@ -100,7 +105,12 @@ namespace Allure.Xunit
         {
             var message = args.Message;
             var test = message.Test;
-            
+
+            if (AllureXunitHelper.IsOnExternalAuthority(test))
+            {
+                return;
+            }
+
             if (!IsStaticTestMethod(message))
             {
                 var testResult = this.GetOrCreateTestData(test).TestResult;
@@ -109,22 +119,46 @@ namespace Allure.Xunit
             }
         }
 
-        void OnTestFailed(MessageHandlerArgs<ITestFailed> args) =>
+        void OnTestFailed(MessageHandlerArgs<ITestFailed> args)
+        {
+            var test = args.Message.Test;
+
+            if (AllureXunitHelper.IsOnExternalAuthority(test))
+            {
+                return;
+            }
+
             this.RunInTestContext(
-                args.Message.Test,
+                test,
                 () => AllureXunitHelper.ApplyTestFailure(args.Message)
             );
+        }
 
-        void OnTestPassed(MessageHandlerArgs<ITestPassed> args) =>
+        void OnTestPassed(MessageHandlerArgs<ITestPassed> args)
+        {
+            var test = args.Message.Test;
+
+            if (AllureXunitHelper.IsOnExternalAuthority(test))
+            {
+                return;
+            }
+
             this.RunInTestContext(
-                args.Message.Test,
+                test,
                 () => AllureXunitHelper.ApplyTestSuccess(args.Message)
             );
+        }
 
         void OnTestSkipped(MessageHandlerArgs<ITestSkipped> args)
         {
             var message = args.Message;
             var test = message.Test;
+
+            if (AllureXunitHelper.IsOnExternalAuthority(test))
+            {
+                return;
+            }
+
             var testData = this.GetOrCreateTestData(test);
             if (testData.IsSelected)
             {
@@ -146,6 +180,12 @@ namespace Allure.Xunit
         {
             var message = args.Message;
             var test = args.Message.Test;
+
+            if (AllureXunitHelper.IsOnExternalAuthority(test))
+            {
+                return;
+            }
+
             var testData = this.GetOrCreateTestData(test);
 
             if (testData.IsSelected)

--- a/Allure.Xunit/AllureXunitConfiguration.cs
+++ b/Allure.Xunit/AllureXunitConfiguration.cs
@@ -11,7 +11,15 @@ namespace Allure.Xunit
 {
     internal class AllureXunitConfiguration : AllureConfiguration
     {
+        const string KNOWN_TOOL_REQNROLL = "Reqnroll";
+        const string KNOWN_TOOL_SPECFLOW = "TechTalk.SpecFlow";
+
         public string XunitRunnerReporter { get; set; } = "auto";
+
+        public List<string> FirstClassIntegrationTools { get; set; } = [
+            KNOWN_TOOL_REQNROLL,
+            KNOWN_TOOL_SPECFLOW,
+        ];
 
         [JsonConstructor]
         protected AllureXunitConfiguration(

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
 using System.Linq;
 using Allure.Net.Commons;
@@ -15,6 +16,17 @@ namespace Allure.Xunit
     {
         internal const string NS_OBSOLETE_MSG =
             "The Allure.XUnit namespace is deprecated. Please, use Allure.Xunit instead";
+
+        /// <summary>
+        /// Returns <c>true</c> if the test is likely reported by another Allure
+        /// integration like Allure.Reqnroll.
+        /// </summary>
+        internal static bool IsOnExternalAuthority(ITest test) =>
+            test.TestCase.TestMethod.TestClass.Class
+                .GetCustomAttributes(typeof(GeneratedCodeAttribute))
+                .Select(a => a.GetNamedArgument<string>(nameof(GeneratedCodeAttribute.Tool)))
+                .Where(v => !string.IsNullOrEmpty(v))
+                .Any(AllureXunitConfiguration.CurrentConfig.FirstClassIntegrationTools.Contains!);
 
         internal static TestResultContainer StartNewAllureContainer(
             string className
@@ -108,7 +120,7 @@ namespace Allure.Xunit
             var className =
                 string.IsNullOrEmpty(@namespace)
                     ? testClass.Name
-                    : testClass.Name?.Substring(@namespace.Length + 1);
+                    : testClass.Name?.Substring(@namespace!.Length + 1);
 
             AllureLifecycle.Instance.UpdateTestCase(
                 testResult => ModelFunctions.EnsureSuites(

--- a/Allure.Xunit/AllureXunitPatcher.cs
+++ b/Allure.Xunit/AllureXunitPatcher.cs
@@ -97,12 +97,24 @@ internal static class AllureXunitPatcher
 
     private static void OnTestRunnerCreating(ITest test, ref string skipReason)
     {
+        if (AllureXunitHelper.IsOnExternalAuthority(test))
+        {
+            return;
+        }
+
         if (!CurrentSink.SelectByTestPlan(test))
         {
             skipReason = AllureTestPlan.SkipReason;
         }
     }
 
-    private static void OnTestRunnerCreated(ITest test, object[] testMethodArguments) =>
+    private static void OnTestRunnerCreated(ITest test, object[] testMethodArguments)
+    {
+        if (AllureXunitHelper.IsOnExternalAuthority(test))
+        {
+            return;
+        }
+
         CurrentSink.OnTestArgumentsCreated(test, testMethodArguments);
+    }
 }

--- a/Allure.Xunit/Schemas/allureConfig.schema.json
+++ b/Allure.Xunit/Schemas/allureConfig.schema.json
@@ -26,6 +26,15 @@
               "description": "The runner switch or the assembly qualified class name of a runner reporter."
             }
           ]
+        },
+        "firstClassIntegrationTools": {
+          "description": "A list of tools that generate xUnit.net tests and have a tool-specific Allure integration enabled in the project. Allure.Xunit will ignore such tests. The test classes produced by the tools must be marked with `[System.CodeDom.Compiler.GeneratedCodeAttribute]` that mentions the tool as the first argument for this feature to work. The default list includes \"Reqnroll\" and \"TechTalk.SpecFlow\".",
+          "default": ["Reqnroll", "TechTalk.SpecFlow"],
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "The name of a tool, i.e., the first argument of `[System.CodeDom.Compiler.GeneratedCodeAttribute]` applied by the tool to generated xUnit.net test classes."
+          }
         }
       }
     }


### PR DESCRIPTION
### Context

Allure.Xunit reports all xUnit.net tests in the project automatically, which interferes with Allure.Reqnroll or 3rd-party integrations with tools that use xUnit.net as a runner.

Usually, when such tools generate test classes, they apply [`[GeneratedCode]`](https://learn.microsoft.com/en-us/dotnet/api/system.codedom.compiler.generatedcodeattribute) to them. The first argument of the attribute identifies the tool that has generated the class.

The PR benefits from this fact by making Allure.Xunit checks the `[GeneratedCode]` attributes of a test class against the list of tools that are known to have a specific Allure integration. If it finds the class has been generated by such a tool, it ignores all tests defined in the class.

By default, the list includes two tools:

  - Reqnroll
  - TechTalk.SpecFlow

This allows including both `Allure.Reqnroll` and `Allure.Xunit` in a project that has a mix of two types of tests:

  - xUnit.net
  - Reqnroll features that are run using the xUnit.net runner

This works out of the box for `Reqnroll` with `Reqnroll.xUnit`.

The list of tools can be customized via the new `firstClassIntegrationTools` configuration property:

```json
{
  "allure": {
    "firstClassIntegrationTools": ["MyTool"]
  }
}
```

The values must match the tool argument of `[GeneratedCode]`:

```csharp
[global::System.CodeDom.Compiler.GeneratedCodeAttribute("MyTool", "1.0.0.0")]
public class TestClassGeneratedByMyTool
{
    // test methods...
}
```

> [!NOTE]
> The name `firstClassIntegrationTools` was chosen instead of something like `ignoredTools` because it makes more sense in the context of a configuration file shared by two Allure integrations, each responsible for their own set of xUnit.tests they consider "first class".

> [!NOTE]
> Setting the property to an empty array will force Reqnroll tests to be reported by Allure.Xunit. It's not recommended, but it works if you can't use `Allure.Reqnroll` in your project for some reason.

Closes #556