### PR TITLE
Change the framework label of Allure.NUnit test results from `NUnit 3` to `NUnit`

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -102,7 +102,7 @@ namespace Allure.NUnit.Core
                     Label.Thread(),
                     Label.Host(),
                     Label.Language(),
-                    Label.Framework("NUnit 3"),
+                    Label.Framework("NUnit"),
                     Label.Package(test.ClassName),
                     Label.TestMethod(test.MethodName),
                     Label.TestClass(


### PR DESCRIPTION
### Context

The PR changes the `framework` label of Allure.NUnit from `NUnit 3` to `NUnit`. The motivation is that Allure.NUnit is compatible with NUnit 4 and is expected to work with future major versions.
