### PR TITLE
Add a `byte[]`-based overload for `AllureApi.AddScreenDiff`

### DIFF
--- a/Allure.Net.Commons.Tests/UserAPITests/AllureFacadeTests/AttachmentTests.cs
+++ b/Allure.Net.Commons.Tests/UserAPITests/AllureFacadeTests/AttachmentTests.cs
@@ -87,4 +87,43 @@ internal class AttachmentTests : AllureApiTestFixture
             Is.Not.Empty
         );
     }
+
+    [Test]
+    public void ScreenDiffFromBytes()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "1", fullName = "n" });
+        byte[] expectedExpected = [1, 2, 3];
+        byte[] expectedActual = [4, 5, 6];
+        byte[] expectedDiff = [7, 8, 9];
+
+        AllureApi.AddScreenDiff(expectedExpected, expectedActual, expectedDiff);
+
+        var attachment = this.Context.CurrentTest.attachments.Single();
+        var content = JsonConvert.DeserializeAnonymousType(
+            Encoding.UTF8.GetString(
+                this.writer.attachments.Single().Content
+            ),
+            new { expected = "", actual = "", diff = "" }
+        );
+        var prefix = "data:image/png;base64,";
+        var actualExpected = Convert.FromBase64String(
+            content.expected[prefix.Length..]
+        );
+        var actualActual = Convert.FromBase64String(
+            content.actual[prefix.Length..]
+        );
+        var actualDiff = Convert.FromBase64String(
+            content.diff[prefix.Length..]
+        );
+
+        Assert.That(attachment.name, Is.EqualTo("diff-1"));
+        Assert.That(attachment.type, Is.EqualTo("application/vnd.allure.image.diff"));
+        Assert.That(attachment.source, Does.EndWith(".json"));
+        Assert.That(content.expected, Does.StartWith(prefix));
+        Assert.That(content.actual, Does.StartWith(prefix));
+        Assert.That(content.diff, Does.StartWith(prefix));
+        Assert.That(actualExpected, Is.EqualTo(expectedExpected));
+        Assert.That(actualActual, Is.EqualTo(expectedActual));
+        Assert.That(actualDiff, Is.EqualTo(expectedDiff));
+    }
 }

--- a/Allure.Net.Commons.Tests/UserAPITests/NoContextTests/AllureApiNoContextTests.cs
+++ b/Allure.Net.Commons.Tests/UserAPITests/NoContextTests/AllureApiNoContextTests.cs
@@ -219,6 +219,7 @@ class AllureApiNoContextTests
     public void AddScreenDiffShouldNotThrow()
     {
         Assert.That(() => AllureApi.AddScreenDiff("foo", "bar", "baz"), Throws.Nothing);
+        Assert.That(() => AllureApi.AddScreenDiff([], [], []), Throws.Nothing);
     }
 
     [Test]


### PR DESCRIPTION
### Context

Some e2e testing tools allow taking screenshots and keeping them in memory instead of writing to files ([example](https://playwright.dev/dotnet/docs/screenshots#capture-into-buffer)). While there is an `AddAttachment` overload that takes a byte array, `AddScreenDiff` only allows attaching from files.

This PR introduces a new `AddScreenDiff` overload, which accepts three byte arrays instead of file paths.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
