### PR TITLE
Create labels from `ALLURE_LABEL_<name>=<value>` environment variables

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -97,8 +97,7 @@ namespace Allure.NUnit.Core
             {
                 name = ResolveDisplayName(test),
                 titlePath = EnumerateNamesFromTestFixtureToRoot(test).Reverse().ToList(),
-                labels = new List<Label>
-                {
+                labels = [
                     Label.Thread(),
                     Label.Host(),
                     Label.Language(),
@@ -107,8 +106,9 @@ namespace Allure.NUnit.Core
                     Label.TestMethod(test.MethodName),
                     Label.TestClass(
                         GetClassName(test.ClassName)
-                    )
-                }
+                    ),
+                    ..ModelFunctions.EnumerateEnvironmentLabels(),
+                ]
             };
             UpdateTestDataFromAllureAttributes(test, testResult);
             AddTestParametersFromNUnit(test, testResult);

--- a/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/LabelsFromEnvVarsTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/LabelsFromEnvVarsTests.cs
@@ -1,0 +1,102 @@
+using NUnit.Framework;
+using Allure.Net.Commons.Functions;
+using System.Collections.Generic;
+
+namespace Allure.Net.Commons.Tests.FunctionTests.ModelFunctionTests;
+
+class LabelsFromEnvVarsTests
+{
+    Dictionary<string, string> env;
+
+    [SetUp]
+    public void SetUpEnvSource()
+    {
+        this.env = [];
+        ModelFunctions.SetGetEnvironmentVariables(() => this.env);
+    }
+
+    [TearDown]
+    public void RemoveEnvSource()
+    {
+        ModelFunctions.SetGetEnvironmentVariables(null);
+    }
+
+    [Test]
+    public void ShouldBeEmtyIfNoVarMatches()
+    {
+        this.env["foo"] = "bar";
+        this.env["bazbazbazbazbazbaz"] = "qux";
+
+        Assert.That(ModelFunctions.EnumerateEnvironmentLabels(), Is.Empty);
+    }
+
+    [Test]
+    public void ShouldIncludeLabelFromMatchingVar()
+    {
+        this.env["ALLURE_LABEL_foo"] = "bar";
+
+        Assert.That(
+            ModelFunctions.EnumerateEnvironmentLabels(),
+            Is.EquivalentTo(new Label[]
+            {
+                new() { name = "foo", value = "bar" },
+            }).UsingPropertiesComparer()
+        );
+    }
+
+    [Test]
+    public void ShouldIncludeMultipleMatchingLabels()
+    {
+        this.env["ALLURE_LABEL_foo"] = "bar";
+        this.env["ALLURE_LABEL_baz"] = "qux";
+        this.env["ALLURE_LABEL_qut"] = "qtu";
+
+        Assert.That(
+            ModelFunctions.EnumerateEnvironmentLabels(),
+            Is.EquivalentTo(new Label[]
+            {
+                new() { name = "foo", value = "bar" },
+                new() { name = "baz", value = "qux" },
+                new() { name = "qut", value = "qtu" },
+            }).UsingPropertiesComparer()
+        );
+    }
+
+    [Test]
+    public void ShouldPreserveCase()
+    {
+        this.env["ALLURE_LABEL_Foo"] = "bar";
+
+        Assert.That(
+            ModelFunctions.EnumerateEnvironmentLabels(),
+            Is.EquivalentTo(new Label[]
+            {
+                new() { name = "Foo", value = "bar" },
+            }).UsingPropertiesComparer()
+        );
+    }
+
+    [Test]
+    public void ShouldIgnoreNullValues()
+    {
+        this.env["ALLURE_LABEL_foo"] = null;
+
+        Assert.That(ModelFunctions.EnumerateEnvironmentLabels(), Is.Empty);
+    }
+
+    [Test]
+    public void ShouldIgnoreEmptyValues()
+    {
+        this.env["ALLURE_LABEL_foo"] = "";
+
+        Assert.That(ModelFunctions.EnumerateEnvironmentLabels(), Is.Empty);
+    }
+
+    [Test]
+    public void ShouldIgnoreEmptyNames()
+    {
+        this.env["ALLURE_LABEL_"] = "bar";
+
+        Assert.That(ModelFunctions.EnumerateEnvironmentLabels(), Is.Empty);
+    }
+}

--- a/Allure.Net.Commons/Functions/ModelFunctions.cs
+++ b/Allure.Net.Commons/Functions/ModelFunctions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 #nullable enable
 
@@ -106,6 +108,35 @@ public static class ModelFunctions
         }
     }
 
+    /// <summary>
+    /// Returns a sequence of labels defined by the environment variables in form
+    /// of <c>ALLURE_LABEL_&lt;name>=&lt;value></c>
+    /// </summary>
+    public static IEnumerable<Label> EnumerateEnvironmentLabels()
+    {
+        foreach (DictionaryEntry entry in GetEnvironmentVariables())
+        {
+            var key = entry.Key as string;
+            var value = entry.Value as string;
+            if (ShouldAddEnvVarAsLabel(key, value))
+            {
+                var name = key.Substring(ENV_LABEL_PATTERN.Length);
+                yield return new() { name = name, value = value };
+            }
+        }
+    }
+
+    static bool ShouldAddEnvVarAsLabel(
+        string? name,
+        string? value
+    ) =>
+        name is not null
+            && name.Length > ENV_LABEL_PATTERN.Length
+            && name.StartsWith(ENV_LABEL_PATTERN)
+            && !string.IsNullOrEmpty(value);
+
+    const string ENV_LABEL_PATTERN = "ALLURE_LABEL_";
+
     static bool IsSuiteLabel(Label label) => label.name switch
     {
         LabelName.PARENT_SUITE or LabelName.SUITE or LabelName.SUB_SUITE => true,
@@ -123,4 +154,18 @@ public static class ModelFunctions
             yield return intetrface.FullName;
         }
     }
+
+    #region For testing
+
+    static IDictionary GetEnvironmentVariables() =>
+        (GetEnvironmentVariablesBox.Value
+            ?? Environment.GetEnvironmentVariables).Invoke();
+
+    internal static void SetGetEnvironmentVariables(Func<IDictionary>? getEnvVars) =>
+        GetEnvironmentVariablesBox.Value = getEnvVars;
+
+    // To decouple from Environment.GetEnvironmentVariable
+    static AsyncLocal<Func<IDictionary>?> GetEnvironmentVariablesBox { get; set; } = new();
+
+    #endregion
 }

--- a/Allure.Net.Commons/Functions/ModelFunctions.cs
+++ b/Allure.Net.Commons/Functions/ModelFunctions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 
@@ -127,8 +128,8 @@ public static class ModelFunctions
     }
 
     static bool ShouldAddEnvVarAsLabel(
-        string? name,
-        string? value
+        [NotNullWhen(true)] string? name,
+        [NotNullWhen(true)] string? value
     ) =>
         name is not null
             && name.Length > ENV_LABEL_PATTERN.Length

--- a/Allure.Net.Commons/Internal/NotNullWhen.cs
+++ b/Allure.Net.Commons/Internal/NotNullWhen.cs
@@ -1,0 +1,14 @@
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>
+/// This attribute hints the compiler that the parameter it's applied to
+/// is not null if the method returns a specified value.
+/// It's not included in netstandard2.0 but can be define it the project's code.
+/// </summary>
+/// <param name="returnValue">
+/// A return value that indicated the argument is not null
+/// </param>
+[AttributeUsage(AttributeTargets.Parameter)]
+internal sealed class NotNullWhenAttribute(bool returnValue) : Attribute {
+    public bool ReturnValue { get; } = returnValue;
+}

--- a/Allure.Reqnroll/Functions/MappingFunctions.cs
+++ b/Allure.Reqnroll/Functions/MappingFunctions.cs
@@ -125,7 +125,7 @@ static class MappingFunctions
                 ".txt"
             ));
         }
-        
+
         var dataTable = stepInfo.Table;
         if (dataTable is not null)
         {
@@ -436,10 +436,11 @@ static class MappingFunctions
     static List<Label> InitializeTestLabels(
         FeatureInfo featureInfo,
         IEnumerable<Label>? scenarioLabels
-    ) =>
-        CreateDefaultLabels(featureInfo)
-            .Concat(scenarioLabels ?? Enumerable.Empty<Label>())
-            .ToList();
+    ) => [
+        .. CreateDefaultLabels(featureInfo),
+        .. ModelFunctions.EnumerateEnvironmentLabels(),
+        .. scenarioLabels ?? [],
+    ];
 
     static IEnumerable<Label> CreateDefaultLabels(FeatureInfo featureInfo)
     {

--- a/Allure.SpecFlow/PluginHelper.cs
+++ b/Allure.SpecFlow/PluginHelper.cs
@@ -95,8 +95,7 @@ namespace Allure.SpecFlowPlugin
                 name = title,
                 description = scenarioInfo.Description,
                 titlePath = CreateTitlePath(testRunnerManager, featureInfo),
-                labels = new List<Label>
-                {
+                labels = [
                     Label.Thread(),
                     string.IsNullOrWhiteSpace(
                         AllureLifecycle.Instance.AllureConfiguration.Title
@@ -105,9 +104,10 @@ namespace Allure.SpecFlowPlugin
                     ),
                     Label.Language(),
                     Label.Framework("SpecFlow"),
-                    Label.Feature(featureInfo.Title)
-                }
-                    .Union(labels).ToList(),
+                    Label.Feature(featureInfo.Title),
+                    ..ModelFunctions.EnumerateEnvironmentLabels(),
+                    ..labels,
+                ],
                 links = links,
                 parameters = parameters
             };

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -154,8 +154,7 @@ namespace Allure.Xunit
             {
                 name = BuildName(testCase),
                 titlePath = IdFunctions.CreateTitlePath(testClass),
-                labels = new()
-                {
+                labels = [
                     Label.Thread(),
                     Label.Host(),
                     Label.Language(),
@@ -163,7 +162,8 @@ namespace Allure.Xunit
                     Label.TestClass(testMethod.TestClass.Class.Name),
                     Label.TestMethod(testCase.TestMethod.Method.Name),
                     Label.Package(testMethod.TestClass.Class.Name),
-                }
+                    ..ModelFunctions.EnumerateEnvironmentLabels(),
+                ]
             };
             SetTestResultIdentifiers(testCase, displayName, testResult);
             UpdateTestDataFromAttributes(testResult, testMethod);


### PR DESCRIPTION
### Context

The PR enables the addition of labels to all test results generated by Allure.NUnit, Allure.Xunit, Allure.Reqnroll, and Allure.SpecFlow from environment variables. An environment variable in the form `ALLURE_LABEL_<name>=<value>`, where name and value are not empty, is converted to the `<name>=<value>` label.

Closes #579

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
