### PR TITLE
Introduce the `globalLabels` configuration property that affects all test results in a run

### DIFF
--- a/Allure.NUnit/Core/AllureNUnitHelper.cs
+++ b/Allure.NUnit/Core/AllureNUnitHelper.cs
@@ -108,6 +108,7 @@ namespace Allure.NUnit.Core
                         GetClassName(test.ClassName)
                     ),
                     ..ModelFunctions.EnumerateEnvironmentLabels(),
+                    ..ModelFunctions.EnumerateGlobalLabels(),
                 ]
             };
             UpdateTestDataFromAllureAttributes(test, testResult);

--- a/Allure.Net.Commons.Tests/ConfigurationTests.cs
+++ b/Allure.Net.Commons.Tests/ConfigurationTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.IO;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Allure.Net.Commons.Tests
 {
@@ -56,6 +57,23 @@ namespace Allure.Net.Commons.Tests
         {
             var json = @"{""allure"":{""indentOutput"": true}}";
             Assert.That(new AllureLifecycle(JObject.Parse(json)).AllureConfiguration.IndentOutput, Is.True);
+        }
+
+        [Test]
+        public void ShouldConfigureGlobalLabels()
+        {
+            var json = @"{""allure"":{""globalLabels"":{""foo"":""bar"",""baz"":""qux""}}}";
+
+            var config = new AllureLifecycle(JObject.Parse(json)).AllureConfiguration;
+
+            Assert.That(
+                config.GlobalLabels,
+                Is.EqualTo(new Dictionary<string, string>
+                {
+                    { "foo", "bar" },
+                    { "baz", "qux" },
+                })
+            );
         }
     }
 }

--- a/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/GlobalLabelsTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/GlobalLabelsTests.cs
@@ -1,0 +1,76 @@
+using NUnit.Framework;
+using Allure.Net.Commons.Functions;
+using System.Collections.Generic;
+using System.Linq;
+using Allure.Net.Commons.Configuration;
+
+namespace Allure.Net.Commons.Tests.FunctionTests.ModelFunctionTests;
+
+class GlobalLabelsTests
+{
+    AllureConfiguration config;
+
+    [SetUp]
+    public void SetUpEnvSource()
+    {
+        this.config = new();
+        ModelFunctions.Config = this.config;
+    }
+
+    [TearDown]
+    public void RemoveEnvSource()
+    {
+        ModelFunctions.Config = null;
+    }
+
+    [Test]
+    public void ShouldNotThrowIfGlobalLabelsNull()
+    {
+        this.config.GlobalLabels = null;
+
+        Assert.That(
+            () => ModelFunctions.EnumerateGlobalLabels().ToList(),
+            Throws.Nothing
+        );
+    }
+
+    [Test]
+    public void ShouldIncludeGlobalLabel()
+    {
+        this.config.GlobalLabels["foo"] = "bar";
+        this.config.GlobalLabels["baz"] = "qux";
+
+        Assert.That(
+            ModelFunctions.EnumerateGlobalLabels(),
+            Is.EquivalentTo(new Label[]
+            {
+                new() { name = "foo", value = "bar" },
+                new() { name = "baz", value = "qux" },
+            }).UsingPropertiesComparer()
+        );
+    }
+
+    [Test]
+    public void ShouldIgnoreNullValues()
+    {
+        this.config.GlobalLabels["foo"] = null;
+
+        Assert.That(ModelFunctions.EnumerateGlobalLabels(), Is.Empty);
+    }
+
+    [Test]
+    public void ShouldIgnoreEmptyValues()
+    {
+        this.config.GlobalLabels["foo"] = "";
+
+        Assert.That(ModelFunctions.EnumerateGlobalLabels(), Is.Empty);
+    }
+
+    [Test]
+    public void ShouldIgnoreEmptyNames()
+    {
+        this.config.GlobalLabels[""] = "foo";
+
+        Assert.That(ModelFunctions.EnumerateGlobalLabels(), Is.Empty);
+    }
+}

--- a/Allure.Net.Commons/AllureLifecycle.cs
+++ b/Allure.Net.Commons/AllureLifecycle.cs
@@ -687,9 +687,6 @@ public class AllureLifecycle
         this.Context = updateFn(this.Context);
     }
 
-    static string CreateUuid() =>
-        Guid.NewGuid().ToString("N");
-
     static Action<T> Chain<T>(params Action<T>[] actions) => v =>
     {
         foreach (var action in actions)

--- a/Allure.Net.Commons/Configuration/AllureConfiguration.cs
+++ b/Allure.Net.Commons/Configuration/AllureConfiguration.cs
@@ -24,6 +24,7 @@ namespace Allure.Net.Commons.Configuration
         public List<string> FailExceptions { get; set; }
         public bool UseLegacyIds { get; set; } = false;
         public bool IndentOutput { get; set; } = false;
+        public Dictionary<string, string> GlobalLabels { get; set; } = [];
 
         public static AllureConfiguration ReadFromJObject(JObject jObject)
         {

--- a/Allure.Net.Commons/Configuration/AllureConfiguration.cs
+++ b/Allure.Net.Commons/Configuration/AllureConfiguration.cs
@@ -20,7 +20,7 @@ namespace Allure.Net.Commons.Configuration
 
         public string Title { get; init; }
         public string Directory { get; init; } = AllureConstants.DEFAULT_RESULTS_FOLDER;
-        public HashSet<string> Links { get; } = new HashSet<string>();
+        public HashSet<string> Links { get; } = [];
         public List<string> FailExceptions { get; set; }
         public bool UseLegacyIds { get; set; } = false;
         public bool IndentOutput { get; set; } = false;

--- a/Allure.Net.Commons/Functions/ModelFunctions.cs
+++ b/Allure.Net.Commons/Functions/ModelFunctions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
+using Allure.Net.Commons.Configuration;
 
 #nullable enable
 
@@ -127,6 +128,15 @@ public static class ModelFunctions
         }
     }
 
+    /// <summary>
+    /// Returns a sequence of labels defined by the <c>globalLabels</c>
+    /// configuration property.
+    /// </summary>
+    public static IEnumerable<Label> EnumerateGlobalLabels() =>
+        from kv in Config.GlobalLabels ?? []
+        where !string.IsNullOrEmpty(kv.Key) && !string.IsNullOrEmpty(kv.Value)
+        select new Label { name = kv.Key, value = kv.Value };
+
     static bool ShouldAddEnvVarAsLabel(
         [NotNullWhen(true)] string? name,
         [NotNullWhen(true)] string? value
@@ -165,8 +175,17 @@ public static class ModelFunctions
     internal static void SetGetEnvironmentVariables(Func<IDictionary>? getEnvVars) =>
         GetEnvironmentVariablesBox.Value = getEnvVars;
 
+    internal static AllureConfiguration Config
+    {
+        get => ConfigBox.Value ?? AllureLifecycle.Instance.AllureConfiguration;
+        set => ConfigBox.Value = value;
+    }
+
     // To decouple from Environment.GetEnvironmentVariable
     static AsyncLocal<Func<IDictionary>?> GetEnvironmentVariablesBox { get; set; } = new();
+
+    // To decouple from AllureLifecycle.Instance.AllureConfiguration
+    static AsyncLocal<AllureConfiguration?> ConfigBox { get; set; } = new();
 
     #endregion
 }

--- a/Allure.Net.Commons/Schemas/allureConfig.schema.json
+++ b/Allure.Net.Commons/Schemas/allureConfig.schema.json
@@ -41,6 +41,13 @@
           "type": "boolean",
           "description": "If set to true, the output JSON files (*-result.json, *-container.json) will be indented to be more readable",
           "default": false
+        },
+        "globalLabels": {
+          "type": "object",
+          "description": "An object that defines the global labels, i.e., labels that are added to every test result produced during the test run. Empty values are ignored",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       }
     }

--- a/Allure.Reqnroll.Tests/Integration/TestSetup.cs
+++ b/Allure.Reqnroll.Tests/Integration/TestSetup.cs
@@ -2,7 +2,7 @@
 using System;
 using System.IO;
 
-namespace Allure.SpecFlowPlugin.Tests
+namespace Allure.ReqnrollPlugin.Tests
 {
     [SetUpFixture]
     public class TestSetup

--- a/Allure.Reqnroll/Functions/MappingFunctions.cs
+++ b/Allure.Reqnroll/Functions/MappingFunctions.cs
@@ -439,6 +439,7 @@ static class MappingFunctions
     ) => [
         .. CreateDefaultLabels(featureInfo),
         .. ModelFunctions.EnumerateEnvironmentLabels(),
+        .. ModelFunctions.EnumerateGlobalLabels(),
         .. scenarioLabels ?? [],
     ];
 

--- a/Allure.SpecFlow.Tests.Samples/allureConfig.json
+++ b/Allure.SpecFlow.Tests.Samples/allureConfig.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://raw.githubusercontent.com/allure-framework/allure-csharp/2.13.0/Allure.SpecFlowPlugin/Schemas/allureConfig.schema.json",
+  "$schema": "https://raw.githubusercontent.com/allure-framework/allure-csharp/2.13.0/Allure.SpecFlow/Schemas/allureConfig.schema.json",
   "allure": {
     "title": "5994A3F7-AF84-46AD-9393-000BB45553CC",
     "directory": "allure-results",

--- a/Allure.SpecFlow/PluginHelper.cs
+++ b/Allure.SpecFlow/PluginHelper.cs
@@ -106,6 +106,7 @@ namespace Allure.SpecFlowPlugin
                     Label.Framework("SpecFlow"),
                     Label.Feature(featureInfo.Title),
                     ..ModelFunctions.EnumerateEnvironmentLabels(),
+                    ..ModelFunctions.EnumerateGlobalLabels(),
                     ..labels,
                 ],
                 links = links,

--- a/Allure.SpecFlow/allureConfig.Template.json
+++ b/Allure.SpecFlow/allureConfig.Template.json
@@ -1,5 +1,5 @@
 ﻿{
-  "$schema": "https://raw.githubusercontent.com/allure-framework/allure-csharp/2.13.0/Allure.SpecFlowPlugin/Schemas/allureConfig.schema.json",
+  "$schema": "https://raw.githubusercontent.com/allure-framework/allure-csharp/2.13.0/Allure.SpecFlow/Schemas/allureConfig.schema.json",
   "allure": {
     "directory": "allure-results",
     "links": [

--- a/Allure.Xunit/AllureXunitHelper.cs
+++ b/Allure.Xunit/AllureXunitHelper.cs
@@ -175,6 +175,7 @@ namespace Allure.Xunit
                     Label.TestMethod(testCase.TestMethod.Method.Name),
                     Label.Package(testMethod.TestClass.Class.Name),
                     ..ModelFunctions.EnumerateEnvironmentLabels(),
+                    ..ModelFunctions.EnumerateGlobalLabels(),
                 ]
             };
             SetTestResultIdentifiers(testCase, displayName, testResult);


### PR DESCRIPTION
### Context

The PR introduces the `globalLabels` configuration property that takes an object whose values must be strings. The key-value pairs of the object are converted to Allure labels for all test results created during the run. This is an alternative to using environment variables, which is the subject of #597.

#### Example

```json
{
  "allure": {
    "globalLabels": {
      "epic": "Core logic",
      "owner": "John Doe <email>",
      "layer": "unit"
    }
  }
}
```

#### Extra changes

  - fix schema link in `allureConfig.json` of SpecFlow testing projects

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
