### PR TITLE
Fix selective run (xunit, specflow) and complex parameter reporting (xunit) on ARM64 machines

### DIFF
--- a/Allure.SpecFlow/Allure.SpecFlow.csproj
+++ b/Allure.SpecFlow/Allure.SpecFlow.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lib.Harmony" Version="2.3.3" />
+        <PackageReference Include="Lib.Harmony" Version="2.4.1" />
         <PackageReference Include="CsvHelper" Version="33.0.1" />
         <PackageReference Include="SpecFlow" Version="3.9.8" />
         <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />

--- a/Allure.Xunit/Allure.Xunit.csproj
+++ b/Allure.Xunit/Allure.Xunit.csproj
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Lib.Harmony" Version="2.3.3" />
+        <PackageReference Include="Lib.Harmony" Version="2.4.1" />
         <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
         <PackageReference Include="xunit.assert" Version="2.4.1" />
         <PackageReference Include="xunit.core" Version="2.4.1" />

--- a/Allure.Xunit/AllureXunitFacade.cs
+++ b/Allure.Xunit/AllureXunitFacade.cs
@@ -11,6 +11,7 @@ namespace Allure.Xunit
 {
     static class AllureXunitFacade
     {
+        internal const string LOG_SOURCE = "Allure.Xunit";
         static readonly Regex REPORTER_ASSEMBLY_PATTERN = new(@".*reporters.*");
         static bool isEnabled = false;
 
@@ -29,7 +30,7 @@ namespace Allure.Xunit
             if (!isEnabled)
             {
                 isEnabled = true;
-                logger.LogImportantMessage(startupMessage);
+                logger.LogImportantMessage("{0}: {1}", LOG_SOURCE, startupMessage);
             }
 
             return sink;

--- a/Allure.Xunit/AllureXunitFacade.cs
+++ b/Allure.Xunit/AllureXunitFacade.cs
@@ -12,6 +12,8 @@ namespace Allure.Xunit
     static class AllureXunitFacade
     {
         static readonly Regex REPORTER_ASSEMBLY_PATTERN = new(@".*reporters.*");
+        static bool isEnabled = false;
+
         internal static IMessageSink CreateAllureXunitMessageHandler(
             IRunnerLogger logger
         )
@@ -23,7 +25,13 @@ namespace Allure.Xunit
                 secondReporter,
                 logger
             );
-            logger.LogImportantMessage(startupMessage);
+
+            if (!isEnabled)
+            {
+                isEnabled = true;
+                logger.LogImportantMessage(startupMessage);
+            }
+
             return sink;
         }
 

--- a/Allure.Xunit/AllureXunitPatcher.cs
+++ b/Allure.Xunit/AllureXunitPatcher.cs
@@ -21,7 +21,10 @@ internal static class AllureXunitPatcher
 
             if (sink is null)
             {
-                _logger.LogWarning("Unable to get current message sink.");
+                _logger.LogWarning(
+                    "{0}: Unable to get current message sink.",
+                    AllureXunitFacade.LOG_SOURCE
+                );
             }
 
             return sink;
@@ -66,7 +69,8 @@ internal static class AllureXunitPatcher
                 wasPatched = true;
 
                 _logger.LogImportantMessage(
-                    "{0}'s {1} has been patched",
+                    "{0}: {1}'s {2} has been patched",
+                    AllureXunitFacade.LOG_SOURCE,
                     testRunnerType.Name,
                     ctor.ToString()
                 );
@@ -74,7 +78,8 @@ internal static class AllureXunitPatcher
             catch (Exception e)
             {
                 _logger.LogWarning(
-                    "Unable to patch {0}'s {1}: {2}",
+                    "{0}: Unable to patch {1}'s {2}: {3}",
+                    AllureXunitFacade.LOG_SOURCE,
                     testRunnerType.Name,
                     ctor.ToString(),
                     e.ToString()
@@ -85,8 +90,9 @@ internal static class AllureXunitPatcher
         if (!wasPatched)
         {
             _logger.LogWarning(
-                "No constructors of {0} were patched. Some theories may " +
+                "{0}: No constructors of {1} were patched. Some theories may " +
                 "miss their parameters in the report",
+                AllureXunitFacade.LOG_SOURCE,
                 testRunnerType.Name
             );
         }

--- a/Allure.Xunit/AllureXunitPatcher.cs
+++ b/Allure.Xunit/AllureXunitPatcher.cs
@@ -32,9 +32,6 @@ internal static class AllureXunitPatcher
     {
         if (_isPatched)
         {
-            _logger.LogMessage(
-                "Patching is skipped: Xunit is already patched"
-            );
             return;
         }
 

--- a/Allure.Xunit/README.md
+++ b/Allure.Xunit/README.md
@@ -137,11 +137,14 @@ dotnet test -s <path-to-runsettings> <test-project-name>
 Check the test logs. If Allure.Xunit has run, the following entry should exist:
 
 ```
-[xUnit.net 00:00:00.53] Allure reporter enabled
+[xUnit.net 00:00:00.53] Allure.Xunit: Allure reporter enabled
 ```
 
-> You might need to increase the verbosity level with `--verbosity=detailed` to
-> see xUnit.net's logs.
+> If you don't see xUnit.net logs, try increasing the verbosity level to `normal` or `detailed`:
+>
+> ```
+> dotnet test --logger 'console;verbosity=normal'
+> ```
 
 ### How to run Allure.Xunit together with another reporter?
 

--- a/Allure.Xunit/README.md
+++ b/Allure.Xunit/README.md
@@ -95,8 +95,7 @@ We rely on Harmony (which in turn uses MonoMod.Core) to:
 1. Report arguments of theories in case they aren't reported by xUnit.net itself.
 2. Implement selectie run (test plans).
 
-Those features are unavailable on ARM64 due to limitations of MonoMod.Core.
-Additionally, they might not work in some other rare circumstances.
+Those features might not work in some rare circumstances, especially when testing the `Release` configuration. If you're affected, try switching to `Debug` as a workaround.
 
 Issue [#369] contains some additional details.
 


### PR DESCRIPTION
### Context

The PR bumps `Lib.Harmony` to 2.4.1, which works on ARM64 machines (including Apple Silicon).

Additionally, this removes the transitive reference to the vulnerable package `System.Text.Json`, as reported in #558.

#### Extra changes

  - Remove the duplicate of the `Allure reporter enabled` message by Allure.Xunit.
  - Prefix log messages by Allure.Xunit with the name of the package.

Fixes #410
Fixes #496
Fixes #500