### PR TITLE
Bump xunit to 2.6.6 in Allure.Xunit

### DIFF
--- a/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
+++ b/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
@@ -18,7 +18,7 @@
         <PackageReference Include="Reqnroll" Version="3.0.3" />
         <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.0.3" />
         <PackageReference Include="Reqnroll.xUnit" Version="3.0.3" />
-        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Allure.Xunit.Examples/Allure.Xunit.Examples.csproj
+++ b/Allure.Xunit.Examples/Allure.Xunit.Examples.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-        <PackageReference Include="xunit" Version="2.9.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Allure.Xunit/Allure.Xunit.csproj
+++ b/Allure.Xunit/Allure.Xunit.csproj
@@ -20,9 +20,9 @@
 
     <ItemGroup>
         <PackageReference Include="Lib.Harmony" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.utility" Version="2.4.1" />
-        <PackageReference Include="xunit.assert" Version="2.4.1" />
-        <PackageReference Include="xunit.core" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.utility" Version="2.6.6" />
+        <PackageReference Include="xunit.assert" Version="2.6.6" />
+        <PackageReference Include="xunit.core" Version="2.6.6" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### Context

The PR bumps the version of xUnit.net packages referenced by Allure.Xunit to 2.6.6. This is the earliest version that targets `netstandard2.0` and doesn't reference `NETStandard.Library`. The reference to `NETStandard.Library` introduced transitive dependencies on vulnerable packages, as noted in #558. Getting rid of this reference fixes this, as xunit itself doesn't use the vulnerable packages in its code.

Another vulnerable package mentioned in the issue is `System.Text.Json`, which is brought by `Lib.Harmony`. This is a subject of #599.

Fixes #558
