### PR TITLE
Add support for parameterized test fixtures to Allure.NUnit

### DIFF
--- a/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
+++ b/Allure.Net.Commons.Tests/FunctionTests/IdTests.cs
@@ -66,8 +66,19 @@ class IdTests
     public void TestFullNameFromClass(Type targetClass, string expectedFullName)
     {
         Assert.That(
-            IdFunctions.CreateFullName(targetClass),
+            IdFunctions.GetTypeId(targetClass),
             Is.EqualTo(expectedFullName)
+        );
+    }
+
+    [Test]
+    public void TestIdOfGenericTypeParameter()
+    {
+        Assert.That(
+            IdFunctions.GetTypeId(
+                typeof(MyClass<>).GetGenericArguments()[0]
+            ),
+            Is.EqualTo("T")
         );
     }
 
@@ -162,8 +173,12 @@ class IdTests
         );
 
         var actualFullName = IdFunctions.CreateFullName(method);
+        var declaringTypeId = IdFunctions.GetTypeId(method.DeclaringType);
+        var methodId = IdFunctions.GetMethodId(method);
 
         Assert.That(actualFullName, Is.EqualTo(expectedFullName));
+        Assert.That(actualFullName, Does.StartWith(declaringTypeId));
+        Assert.That(actualFullName, Does.EndWith(methodId));
     }
 
     [Test]

--- a/Allure.Net.Commons/Functions/FormatFunctions.cs
+++ b/Allure.Net.Commons/Functions/FormatFunctions.cs
@@ -25,7 +25,19 @@ public static class FormatFunctions
     /// </summary>
     public static string Format(object? value)
     {
-        return Format(value, new Dictionary<Type, ITypeFormatter>());
+        if (value is null)
+        {
+            return "null";
+        }
+
+        try
+        {
+            return JsonConvert.SerializeObject(value, SerializerSettings);
+        }
+        catch
+        {
+            return value.ToString();
+        }
     }
 
     /// <summary>
@@ -47,18 +59,6 @@ public static class FormatFunctions
             return formatter.Format(value);
         }
 
-        if (value is null)
-        {
-            return "null";
-        }
-
-        try
-        {
-            return JsonConvert.SerializeObject(value, SerializerSettings);
-        }
-        catch
-        {
-            return value.ToString();
-        }
+        return Format(value);
     }
 }


### PR DESCRIPTION
### Context

The PR includes test fixture parameters to `fullName` values of the fixture's tests.

Fixes #417
