### PR TITLE
Bump test frameworks in test projects

### DIFF
--- a/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
+++ b/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     </ItemGroup>
 

--- a/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
+++ b/Allure.NUnit.Examples/Allure.NUnit.Examples.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     </ItemGroup>

--- a/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
+++ b/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
@@ -9,7 +9,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
+++ b/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="Castle.Core" Version="5.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     </ItemGroup>
 

--- a/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
+++ b/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj
@@ -15,9 +15,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Castle.Core" Version="5.1.1" />
-        <PackageReference Include="Reqnroll" Version="3.0.3" />
-        <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.0.3" />
-        <PackageReference Include="Reqnroll.xUnit" Version="3.0.3" />
+        <PackageReference Include="Reqnroll" Version="3.1.2" />
+        <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.1.2" />
+        <PackageReference Include="Reqnroll.xUnit" Version="3.1.2" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
             <PrivateAssets>all</PrivateAssets>

--- a/Allure.Reqnroll.Tests/Allure.Reqnroll.Tests.csproj
+++ b/Allure.Reqnroll.Tests/Allure.Reqnroll.Tests.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Allure.Reqnroll.Tests/Allure.Reqnroll.Tests.csproj
+++ b/Allure.Reqnroll.Tests/Allure.Reqnroll.Tests.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     </ItemGroup>
 

--- a/Allure.SpecFlow.Tests.Samples/Allure.SpecFlow.Tests.Samples.csproj
+++ b/Allure.SpecFlow.Tests.Samples/Allure.SpecFlow.Tests.Samples.csproj
@@ -8,7 +8,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Castle.Core" Version="5.1.1" />
         <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
         <PackageReference Include="SpecFlow.SharedSteps" Version="3.0.7" />
 
         <!-- SpecFlow.SharedSteps doesn't work with SpecFlow.Tools.MsBuild.Generation v3.9.58+  -->

--- a/Allure.SpecFlow.Tests.Samples/Allure.SpecFlow.Tests.Samples.csproj
+++ b/Allure.SpecFlow.Tests.Samples/Allure.SpecFlow.Tests.Samples.csproj
@@ -7,7 +7,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="Castle.Core" Version="5.1.1" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
         <PackageReference Include="SpecFlow.SharedSteps" Version="3.0.7" />
 

--- a/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj
+++ b/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
         <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj
+++ b/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     </ItemGroup>
 


### PR DESCRIPTION
  - Allure.NUnit.Examples
      - NUnit 4.1.0 -> 4.4.0
      - NUnit3TestAdapter 4.6.0 -> 5.2.0
  - Allure.Net.Commons.Tests
      - NUnit 4.1.0 -> 4.4.0
      - NUnit3TestAdapter 4.6.0 -> 5.2.0
  - Allure.Reqnroll.Tests
      - NUnit 4.1.0 -> 4.4.0
      - NUnit3TestAdapter 4.6.0 -> 5.2.0
  - Allure.Reqnroll.Tests.Samples
      - Reqnroll 3.0.3 -> 3.1.2
      - Reqnroll.Tools.MsBuild.Generation 3.0.3 -> 3.1.2
      - Reqnroll.xUnit 3.0.3 -> 3.1.2
  - Allure.SpecFlow.Tests
      - NUnit 4.1.0 -> 4.4.0
      - NUnit3TestAdapter 4.6.0 -> 5.2.0
  - Allure.SpecFlow.Tests.Samples
      - NUnit 4.1.0 -> 4.4.0
      - NUnit3TestAdapter 4.6.0 -> 5.2.0