### PR TITLE
Revert AspectInjector back to 2.8.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,9 @@ jobs:
           Write-Host "Found '$SnExeLocation'"
           "path=$SnExeLocation" >> $Env:GITHUB_OUTPUT
 
+      # Use AspectInjector 2.8.2 which, unlike 2.8.1, correctly sets PdbChecksum
+      # The only reason we're still referencing 2.8.1 from projects is that
+      # 2.8.2 doesn't work well on Mac OS ARM
       - name: 'Build project using dotnet'
         shell: pwsh
         run: |
@@ -45,7 +48,8 @@ jobs:
             --no-restore `
             --configuration ${{ env.BUILD_CONFIGURATION }} `
             -p:ContinuousIntegrationBuild=true `
-            "-p:Allure_SnExePath=${{ steps.find-snexe.outputs.path }}"
+            "-p:Allure_SnExePath=${{ steps.find-snexe.outputs.path }}" `
+            "-p:AspectInjector_Location=${{ github.workspace }}/build/AspectInjector/win-x64/AspectInjector.exe"
 
       - name: Verify assembly strong names
         shell: pwsh

--- a/Allure.NUnit/README.md
+++ b/Allure.NUnit/README.md
@@ -89,3 +89,15 @@ The following previously deprecated user API classes and methods were removed:
       instead.
   - `Allure.Net.Commons.Steps.CoreStepsHelper` - use functions from
     `Allure.Net.Commons.AllureApi` and `Allure.Net.Commons.ExtendedApi` instead.
+
+### For users of Mac with Apple silicon
+
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```

--- a/Allure.Net.Commons/Allure.Net.Commons.csproj
+++ b/Allure.Net.Commons/Allure.Net.Commons.csproj
@@ -14,7 +14,7 @@
         <None Include="README.md" Pack="true" PackagePath="\" />
         <None Include="./../img/Allure-Color.png" Pack="true" PackagePath="\" />
         <Content Include="allureConfig.Template.json" Pack="true" />
-        <PackageReference Include="AspectInjector" Version="2.9.0" />
+        <PackageReference Include="AspectInjector" Version="2.8.1" />
         <PackageReference Include="MimeTypesMap" Version="1.0.9" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />

--- a/Allure.Net.Commons/README.md
+++ b/Allure.Net.Commons/README.md
@@ -21,6 +21,18 @@ The library can be used by any project that targets a framework compatible with
 .NET Standard 2.0 (.NET Framework 4.6.1+, .NET Core 2.0+, .NET 5.0+, and more).
 See the complete list [here](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version).
 
+## Note for users of Mac with Apple silicon
+
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 ## Configuration
 
 The Allure lifecycle is configured via a JSON file with the default name

--- a/Allure.SpecFlow/README.md
+++ b/Allure.SpecFlow/README.md
@@ -35,6 +35,18 @@ Nuget package according to your SpecFlow version.
 
 3. Run the tests.
 
+#### For users of Mac with Apple silicon
+
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 ### Further readings
 
 Learn more from [the documentation for Allure SpecFlow](https://allurereport.org/docs/specflow/).

--- a/Allure.Xunit/README.md
+++ b/Allure.Xunit/README.md
@@ -88,6 +88,18 @@ You should uninstall it and use attributes from the
 
 ## Known issues and limitations
 
+### Rosetta is required for users on Mac with Apple silicon
+
+If you're developing on a Mac machine with Apple silicon, make sure you have
+Rosetta installed. Follow this article for the instructions:
+https://support.apple.com/en-us/HT211861
+
+You may also install Rosetta via the CLI:
+
+```shell
+/usr/sbin/softwareupdate --install-rosetta --agree-to-license
+```
+
 ### MonoMod.Core issues
 
 We rely on Harmony (which in turn uses MonoMod.Core) to:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -61,7 +61,7 @@
     </Target>
 
     <Target Name="Allure_SetAssemblyTimestampAfterAspectInjection"
-            AfterTargets="AspectInjector_InjectAspects"
+            AfterTargets="AspectInjector_InjectAspects;InjectAspects"
             BeforeTargets="Allure_UpdateStrongNameSignatures">
         <PropertyGroup>
             <Allure_AssemblyTimestampAfterAspectInjection>%(IntermediateAssembly.ModifiedTime)</Allure_AssemblyTimestampAfterAspectInjection>
@@ -81,12 +81,36 @@
                 And Exists('$(AssemblyOriginatorKeyFile)')
                 And Exists('$(Allure_SnExePath)')
                 And '$(Allure_AssemblyTimestampBeforeAspectInjection)' != '$(Allure_AssemblyTimestampAfterAspectInjection)'"
-            AfterTargets="AspectInjector_InjectAspects"
+            AfterTargets="AspectInjector_InjectAspects;InjectAspects"
             BeforeTargets="_TimeStampAfterCompile;AfterCompile">
         <Exec   UseUtf8Encoding="Always"
                 StdOutEncoding="UTF-8"
                 StdErrEncoding="UTF-8"
                 Command="&quot;$(Allure_SnExePath)&quot; -Ra &quot;%(IntermediateAssembly.FullPath)&quot; &quot;$(AssemblyOriginatorKeyFile)&quot;"
         />
+    </Target>
+
+    <!-- A hacky way to skip AspectInjector's own re-signing logic,
+     which doesn't work on Linux/Mac (unless there is an sn binary in PATH).
+     It's not relevant for AspectInjector 2.9.0+ and should be removed as
+     soon as we upgrade. -->
+
+    <Target Name="Allure_DisableAspectInjector"
+            BeforeTargets="_ASI_ResignAssembly"
+            AfterTargets="_ASI_InjectAspectsCore"
+            Condition=" '$(_InjectionNeeded)' == 'true' ">
+        <PropertyGroup>
+            <Allure_ShouldEnableAspectInjector>true</Allure_ShouldEnableAspectInjector>
+            <_InjectionNeeded>false</_InjectionNeeded>
+        </PropertyGroup>
+    </Target>
+
+    <Target Name="Allure_EnableAspectInjector"
+            BeforeTargets="_ASI_TouchTimestampFile"
+            AfterTargets="_ASI_ResignAssembly"
+            Condition=" '$(Allure_ShouldEnableAspectInjector)' == 'true' ">
+        <PropertyGroup>
+            <_InjectionNeeded>true</_InjectionNeeded>
+        </PropertyGroup>
     </Target>
 </Project>


### PR DESCRIPTION
### Context

There are some assembly locking issues reported when using AspectInjector 2.9.0 as an MSBuild task, see #617 and pamidur/aspect-injector#244. This PR reverts the minimal required verison back to 2.8.1 until the issue is resolved.

> [!NOTE]
> If someone needs 2.9.0 (e.g., if using on an an ARM64 MAC machine without Rosetta), they can always reference it explicitly.
