### PR TITLE
Fix "Test host process crashed" when a theory data member throws

### DIFF
--- a/src/Allure.Xunit/AllureMessageSink.cs
+++ b/src/Allure.Xunit/AllureMessageSink.cs
@@ -128,10 +128,18 @@ namespace Allure.Xunit
                 return;
             }
 
-            this.RunInTestContext(
-                test,
-                () => AllureXunitHelper.ApplyTestFailure(args.Message)
-            );
+            var testData = this.GetOrCreateTestData(test);
+            this.UpdateTestContext(test, () =>
+            {
+                if (!AllureContext.HasTest)
+                {
+                    AllureXunitHelper.StartAllureTestCase(
+                        test,
+                        testData.TestResult
+                    );
+                }
+                AllureXunitHelper.ApplyTestFailure(args.Message);
+            });
         }
 
         void OnTestPassed(MessageHandlerArgs<ITestPassed> args)
@@ -143,10 +151,18 @@ namespace Allure.Xunit
                 return;
             }
 
-            this.RunInTestContext(
-                test,
-                () => AllureXunitHelper.ApplyTestSuccess(args.Message)
-            );
+            var testData = this.GetOrCreateTestData(test);
+            this.UpdateTestContext(test, () =>
+            {
+                if (!AllureContext.HasTest)
+                {
+                    AllureXunitHelper.StartAllureTestCase(
+                        test,
+                        testData.TestResult
+                    );
+                }
+                AllureXunitHelper.ApplyTestSuccess(args.Message);
+            });
         }
 
         void OnTestSkipped(MessageHandlerArgs<ITestSkipped> args)

--- a/tests/Allure.Xunit.Tests/BrokenDataSourceTests.cs
+++ b/tests/Allure.Xunit.Tests/BrokenDataSourceTests.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Nodes;
+using Allure.Testing;
+
+namespace Allure.Xunit.Tests;
+
+class BrokenDataSourceTests
+{
+    [Test]
+    public async Task TheoryWithThrowingMemberDataIsRecordedAsBroken()
+    {
+        var results = await AllureSampleRunner.RunAsync(
+            AllureSampleRegistry.TheoryWithThrowingMemberData
+        );
+
+        await Assert.That(results.TestResults.Cast<JsonObject>()).Count().IsEqualTo(1);
+        await Assert.That((string)results.TestResults[0]["status"]).IsEqualTo("broken");
+    }
+}

--- a/tests/Allure.Xunit.Tests/Samples/TheoryWithThrowingMemberData.cs
+++ b/tests/Allure.Xunit.Tests/Samples/TheoryWithThrowingMemberData.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Allure.Xunit.Tests.Samples.TheoryWithThrowingMemberData
+{
+    public class TestsClass
+    {
+        public static IEnumerable<object[]> ThrowingData() =>
+            throw new InvalidOperationException("Data source exploded!");
+
+        [Theory]
+        [MemberData(nameof(ThrowingData))]
+        public void TestMethod(int _) { }
+    }
+}


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter, and no dot is required at the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

hope it solves #528 , assisted by QWEN code

This pull request improves the handling and reporting of test cases in scenarios where test data sources throw exceptions, ensuring that such cases are properly recorded as "broken" in the Allure test results. It also refactors the test context management logic for test pass and fail events to ensure Allure test cases are started correctly when needed.

**Enhancements to test result handling:**

* Refactored the logic in `OnTestFailed` and `OnTestPassed` in `AllureMessageSink.cs` to use `UpdateTestContext` and ensure that Allure test cases are started if not already present, improving reliability in test case lifecycle management. [[1]](diffhunk://#diff-c016599c06ea047dfa9614bb00bca333462071477ed47769ebdb21756f247caeL131-R143) [[2]](diffhunk://#diff-c016599c06ea047dfa9614bb00bca333462071477ed47769ebdb21756f247caeL146-R166)
`OnTestSkipped` already handles this case defensively. OnTestFailed and OnTestPassed don't. The fix is to apply the same pattern.

**Support and testing for broken data sources:**

* Added a new test `TheoryWithThrowingMemberDataIsRecordedAsBroken` in `BrokenDataSourceTests.cs` to verify that theories with member data sources that throw exceptions are marked as "broken" in the test results.
* Introduced a sample test class `TheoryWithThrowingMemberData` where the data source method intentionally throws an exception, to support the new test scenario.


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
