### PR TITLE
New API for global errors and attachments

### DIFF
--- a/src/Allure.Net.Commons/AllureApi.cs
+++ b/src/Allure.Net.Commons/AllureApi.cs
@@ -528,6 +528,87 @@ public static class AllureApi
     }
 
     /// <summary>
+    /// Adds a global attachment not tied to the current fixture, test, or step.
+    /// </summary>
+    /// <param name="name">The name of the attachment.</param>
+    /// <param name="type">The MIME type of the attachment.</param>
+    /// <param name="path">The path to the attached file.</param>
+    public static void AddGlobalAttachment(
+        string name,
+        string type,
+        string path
+    ) =>
+        AddGlobalAttachmentInternal(
+            name: name ?? Path.GetFileName(path),
+            type: type,
+            content: File.ReadAllBytes(path),
+            fileExtension: Path.GetExtension(path)
+        );
+
+    /// <summary>
+    /// Adds a global attachment not tied to the current fixture, test, or step.
+    /// </summary>
+    /// <param name="name">The name of the attachment.</param>
+    /// <param name="type">The MIME type of the attachment.</param>
+    /// <param name="content">The content of the attachment.</param>
+    /// <param name="fileExtension">
+    /// The extension of the file that will be available for downloading.
+    /// </param>
+    public static void AddGlobalAttachment(
+        string name,
+        string type,
+        byte[] content,
+        string fileExtension = ""
+    ) => AddGlobalAttachmentInternal(name, type, content, fileExtension);
+
+    /// <summary>
+    /// Adds a global attachment not tied to the current fixture, test, or step.
+    /// </summary>
+    /// <param name="path">The path to the attached file.</param>
+    /// <param name="name">
+    /// The name of the attachment. If null, the file name is used.
+    /// </param>
+    public static void AddGlobalAttachment(
+        string path,
+        string? name = null
+    ) =>
+        AddGlobalAttachmentInternal(
+            name: name ?? Path.GetFileName(path),
+            type: MimeTypesMap.GetMimeType(path),
+            content: File.ReadAllBytes(path),
+            fileExtension: Path.GetExtension(path)
+        );
+
+    /// <summary>
+    /// Adds a global error not tied to the current fixture, test, or step.
+    /// </summary>
+    /// <param name="error">The error to persist.</param>
+    public static void AddGlobalError(Exception error) =>
+        AddGlobalErrorInternal(
+            CreateGlobalError(
+                ModelFunctions.ToStatusDetails(error)
+            )
+        );
+
+    /// <summary>
+    /// Adds a global error not tied to the current fixture, test, or step.
+    /// </summary>
+    /// <param name="message">The error message to persist.</param>
+    public static void AddGlobalError(string message) =>
+        AddGlobalErrorInternal(
+            CreateGlobalError(
+                new StatusDetails { message = message }
+            )
+        );
+
+    /// <summary>
+    /// Adds a global error not tied to the current fixture, test, or step.
+    /// </summary>
+    /// <param name="statusDetails">The error details to persist.</param>
+    public static void AddGlobalError(StatusDetails statusDetails) =>
+        AddGlobalErrorInternal(CreateGlobalError(statusDetails));
+
+    /// <summary>
     /// Attaches screen diff images to the current fixture, test, or step.
     /// </summary>
     /// <remarks>If no test or fixture is running, does nothing.</remarks>
@@ -801,9 +882,7 @@ public static class AllureApi
         string fileExtension
     )
     {
-        var suffix = AllureConstants.ATTACHMENT_FILE_SUFFIX;
-        var uuid = IdFunctions.CreateUUID();
-        var source = $"{uuid}{suffix}{fileExtension}";
+        var source = CreateAttachmentSource(fileExtension);
         var attachment = new Attachment
         {
             name = name,
@@ -814,6 +893,62 @@ public static class AllureApi
         CurrentLifecycle.UpdateExecutableItem(
             item => item.attachments.Add(attachment)
         );
+    }
+
+    internal static void AddGlobalAttachmentInternal(
+        string name,
+        string? type,
+        byte[] content,
+        string fileExtension
+    )
+    {
+        var timestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        var source = CreateAttachmentSource(fileExtension);
+        CurrentLifecycle.Writer.Write(source, content);
+        CurrentLifecycle.Writer.Write(
+            new Globals
+            {
+                attachments = new()
+                {
+                    new GlobalAttachment
+                    {
+                        name = name,
+                        type = type,
+                        source = source,
+                        timestamp = timestamp
+                    }
+                }
+            }
+        );
+    }
+
+    internal static void AddGlobalErrorInternal(GlobalError error) =>
+        CurrentLifecycle.Writer.Write(
+            new Globals
+            {
+                errors = new() { error }
+            }
+        );
+
+    static string CreateAttachmentSource(string fileExtension)
+    {
+        var suffix = AllureConstants.ATTACHMENT_FILE_SUFFIX;
+        var uuid = IdFunctions.CreateUUID();
+        return $"{uuid}{suffix}{fileExtension}";
+    }
+
+    static GlobalError CreateGlobalError(StatusDetails? statusDetails)
+    {
+        statusDetails ??= new StatusDetails();
+        return new GlobalError
+        {
+            message = statusDetails.message,
+            trace = statusDetails.trace,
+            flaky = statusDetails.flaky,
+            muted = statusDetails.muted,
+            known = statusDetails.known,
+            timestamp = DateTimeOffset.Now.ToUnixTimeMilliseconds()
+        };
     }
 
     static void AddScreenDiffInternal(

--- a/src/Allure.Net.Commons/AllureConstants.cs
+++ b/src/Allure.Net.Commons/AllureConstants.cs
@@ -8,6 +8,7 @@
 
         public const string TEST_RESULT_FILE_SUFFIX = "-result.json";
         public const string TEST_RESULT_CONTAINER_FILE_SUFFIX = "-container.json";
+        public const string GLOBALS_FILE_SUFFIX = "-globals.json";
         public static string TEST_RUN_FILE_SUFFIX = "-testrun.json";
         public const string ATTACHMENT_FILE_SUFFIX = "-attachment";
 

--- a/src/Allure.Net.Commons/Attributes/AllureAttachmentAttribute.cs
+++ b/src/Allure.Net.Commons/Attributes/AllureAttachmentAttribute.cs
@@ -51,6 +51,12 @@ public class AllureAttachmentAttribute : Attribute
     public string? Encoding { get; init; }
 
     /// <summary>
+    /// If set to <c>true</c>, creates a global attachment not tied to the current
+    /// test, fixture, or step.
+    /// </summary>
+    public bool Global { get; init; }
+
+    /// <summary>
     /// Creates attachments named after the method.
     /// </summary>
     public AllureAttachmentAttribute() { }

--- a/src/Allure.Net.Commons/Attributes/AllureAttachmentFileAttribute.cs
+++ b/src/Allure.Net.Commons/Attributes/AllureAttachmentFileAttribute.cs
@@ -33,6 +33,12 @@ public class AllureAttachmentFileAttribute : Attribute
     public string? ContentType { get; init; }
 
     /// <summary>
+    /// If set to <c>true</c>, creates a global attachment not tied to the current
+    /// test, fixture, or step.
+    /// </summary>
+    public bool Global { get; init; }
+
+    /// <summary>
     /// Creates attachments with the same names as the original files.
     /// </summary>
     public AllureAttachmentFileAttribute() { }

--- a/src/Allure.Net.Commons/Model/allure2.Designer.cs
+++ b/src/Allure.Net.Commons/Model/allure2.Designer.cs
@@ -548,6 +548,89 @@ namespace Allure.Net.Commons
     }
 
     [System.Diagnostics.DebuggerStepThroughAttribute()]
+    public partial class GlobalAttachment : Attachment
+    {
+
+        #region Private fields
+        private long _timestamp;
+        #endregion
+
+        public long timestamp
+        {
+            get
+            {
+                return this._timestamp;
+            }
+            set
+            {
+                this._timestamp = value;
+            }
+        }
+    }
+
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    public partial class GlobalError : StatusDetails
+    {
+
+        #region Private fields
+        private long _timestamp;
+        #endregion
+
+        public long timestamp
+        {
+            get
+            {
+                return this._timestamp;
+            }
+            set
+            {
+                this._timestamp = value;
+            }
+        }
+    }
+
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    public partial class Globals
+    {
+
+        #region Private fields
+        private List<GlobalAttachment> _attachments;
+
+        private List<GlobalError> _errors;
+        #endregion
+
+        public Globals()
+        {
+            this._attachments = new List<GlobalAttachment>();
+            this._errors = new List<GlobalError>();
+        }
+
+        public List<GlobalAttachment> attachments
+        {
+            get
+            {
+                return this._attachments;
+            }
+            set
+            {
+                this._attachments = value;
+            }
+        }
+
+        public List<GlobalError> errors
+        {
+            get
+            {
+                return this._errors;
+            }
+            set
+            {
+                this._errors = value;
+            }
+        }
+    }
+
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
     public partial class Parameter
     {
 

--- a/src/Allure.Net.Commons/Sdk/Aspects/AllureAttachmentAspect.cs
+++ b/src/Allure.Net.Commons/Sdk/Aspects/AllureAttachmentAspect.cs
@@ -25,19 +25,27 @@ public class AllureAttachmentAspect
         [Argument(Source.ReturnValue)] object? returnValue
     )
     {
-        if (!AllureApi.HasTestOrFixture)
+        var attr = metadata.GetCustomAttribute<AllureAttachmentAttribute>();
+        var isGlobal = attr?.Global == true;
+
+        if (!isGlobal && !AllureApi.HasTestOrFixture)
         {
             return;
         }
-
-        var attr = metadata.GetCustomAttribute<AllureAttachmentAttribute>();
 
         var attachmentName = ResolveAttachmentName(attr, name, metadata, arguments);
         var contentType = ResolveContentType(attr, returnType);
         var extension = ResolveExtension(attr, contentType);
         byte[] content = ResolveContent(attr, returnValue);
 
-        AllureApi.AddAttachmentInternal(attachmentName, contentType, content, extension);
+        if (isGlobal)
+        {
+            AllureApi.AddGlobalAttachmentInternal(attachmentName, contentType, content, extension);
+        }
+        else
+        {
+            AllureApi.AddAttachmentInternal(attachmentName, contentType, content, extension);
+        }
     }
 
     static string ResolveAttachmentName(

--- a/src/Allure.Net.Commons/Sdk/Aspects/AllureAttachmentFileAspect.cs
+++ b/src/Allure.Net.Commons/Sdk/Aspects/AllureAttachmentFileAspect.cs
@@ -24,7 +24,10 @@ public class AllureAttachmentFileAspect
         [Argument(Source.ReturnValue)] object? returnValue
     )
     {
-        if (!AllureApi.HasTestOrFixture)
+        var attr = metadata.GetCustomAttribute<AllureAttachmentFileAttribute>();
+        var isGlobal = attr?.Global == true;
+
+        if (!isGlobal && !AllureApi.HasTestOrFixture)
         {
             return;
         }
@@ -35,14 +38,19 @@ public class AllureAttachmentFileAspect
             return;
         }
 
-        var attr = metadata.GetCustomAttribute<AllureAttachmentFileAttribute>();
-
         var attachmentName = ResolveAttachmentName(attachmentFile, attr, metadata, arguments);
         var contentType = attr?.ContentType;
         var extension = ResolveExtension(attachmentFile, contentType);
         var content = File.ReadAllBytes(attachmentFile.FullName);
 
-        AllureApi.AddAttachmentInternal(attachmentName, contentType, content, extension);
+        if (isGlobal)
+        {
+            AllureApi.AddGlobalAttachmentInternal(attachmentName, contentType, content, extension);
+        }
+        else
+        {
+            AllureApi.AddAttachmentInternal(attachmentName, contentType, content, extension);
+        }
     }
 
     static FileInfo? ResolveFile(object? value) => value switch

--- a/src/Allure.Net.Commons/Writer/FileSystemResultsWriter.cs
+++ b/src/Allure.Net.Commons/Writer/FileSystemResultsWriter.cs
@@ -47,6 +47,11 @@ namespace Allure.Net.Commons.Writer
             Write(testResult, AllureConstants.TEST_RESULT_CONTAINER_FILE_SUFFIX);
         }
 
+        public void Write(Globals globals)
+        {
+            Write(globals, AllureConstants.GLOBALS_FILE_SUFFIX);
+        }
+
         public void Write(string source, byte[] content)
         {
             using var task = new WriteTask { Filepath = Path.Combine(outputDirectory, source), Content = content };

--- a/src/Allure.Net.Commons/Writer/IAllureResultsWriter.cs
+++ b/src/Allure.Net.Commons/Writer/IAllureResultsWriter.cs
@@ -4,6 +4,7 @@
     {
         void Write(TestResult testResult);
         void Write(TestResultContainer testResult);
+        void Write(Globals globals);
         void Write(string source, byte[] attachment);
         void CleanUp();
     }

--- a/tests/Allure.Net.Commons.Tests/FileSystemResultsWriterTests.cs
+++ b/tests/Allure.Net.Commons.Tests/FileSystemResultsWriterTests.cs
@@ -86,5 +86,28 @@ namespace Allure.Net.Commons.Tests
             var resultJson = File.ReadAllText(resultFile.FullName, Encoding.UTF8);
             Assert.That(resultJson, Does.Contain("  "));
         }
+
+        [Test]
+        public void ShouldWriteGlobalsChunk()
+        {
+            var config = new AllureConfiguration { Directory = this.tmpDir.FullName };
+            var writer = new FileSystemResultsWriter(config);
+            var globals = new Globals
+            {
+                errors = new()
+                {
+                    new GlobalError { message = "boom", timestamp = 1 }
+                }
+            };
+
+            writer.Write(globals);
+
+            var resultFile = this.tmpDir.EnumerateFiles().Single();
+            var resultJson = JObject.Parse(File.ReadAllText(resultFile.FullName, Encoding.UTF8));
+            Assert.That(resultFile.Name, Does.EndWith(AllureConstants.GLOBALS_FILE_SUFFIX));
+            Assert.That(resultJson["attachments"], Is.Not.Null);
+            Assert.That(resultJson["errors"], Is.Not.Null);
+            Assert.That(resultJson["errors"]!.Single()!["message"]!.Value<string>(), Is.EqualTo("boom"));
+        }
     }
 }

--- a/tests/Allure.Net.Commons.Tests/InMemoryResultsWriter.cs
+++ b/tests/Allure.Net.Commons.Tests/InMemoryResultsWriter.cs
@@ -8,6 +8,7 @@ namespace Allure.Net.Commons.Tests
         readonly object monitor = new();
         internal List<TestResult> testResults = new();
         internal List<TestResultContainer> testContainers = new();
+        internal List<Globals> globals = new();
         internal List<(string Source, byte[] Content)> attachments = new();
 
         public void CleanUp()
@@ -16,6 +17,7 @@ namespace Allure.Net.Commons.Tests
             {
                 this.testResults.Clear();
                 this.testContainers.Clear();
+                this.globals.Clear();
                 this.attachments.Clear();
             }
         }
@@ -33,6 +35,14 @@ namespace Allure.Net.Commons.Tests
             lock (this.monitor)
             {
                 this.testContainers.Add(testResult);
+            }
+        }
+
+        public void Write(Globals globals)
+        {
+            lock (this.monitor)
+            {
+                this.globals.Add(globals);
             }
         }
 

--- a/tests/Allure.Net.Commons.Tests/UserAPITests/AllureFacadeTests/GlobalTests.cs
+++ b/tests/Allure.Net.Commons.Tests/UserAPITests/AllureFacadeTests/GlobalTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Allure.Net.Commons.Tests.UserApiTests.AllureFacadeTests;
+
+internal class GlobalTests : AllureApiTestFixture
+{
+    [Test]
+    public void GlobalAttachmentFromBytesWritesAttachmentAndGlobalsChunk()
+    {
+        byte[] expectedContent = [1, 2, 3];
+
+        var timestampBefore = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        AllureApi.AddGlobalAttachment("global", "text/plain", expectedContent, ".txt");
+        var timestampAfter = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+        Assert.That(this.writer.attachments, Has.One.Items);
+        Assert.That(this.writer.globals, Has.One.Items);
+
+        var global = this.writer.globals[0];
+        var (actualSource, actualContent) = this.writer.attachments[0];
+
+        Assert.That(global.attachments, Has.One.Items);
+        Assert.That(global.errors, Is.Empty);
+
+        var globalAttachment = global.attachments[0];
+
+        Assert.That(globalAttachment.name, Is.EqualTo("global"));
+        Assert.That(globalAttachment.type, Is.EqualTo("text/plain"));
+        Assert.That(globalAttachment.source, Does.EndWith(".txt"));
+        Assert.That(
+            globalAttachment.timestamp,
+            Is.GreaterThanOrEqualTo(timestampBefore)
+                .And.LessThanOrEqualTo(timestampAfter));
+        Assert.That(actualSource, Is.EqualTo(globalAttachment.source));
+        Assert.That(actualContent, Is.EqualTo(expectedContent));
+    }
+
+    [Test]
+    public void GlobalAttachmentFromPathUsesFileNameAndMimeType()
+    {
+        var (path, content) = DataGenerator.GetAttachment(".txt");
+
+        try
+        {
+            var expectedFileName = Path.GetFileName(path);
+
+            AllureApi.AddGlobalAttachment(path);
+
+            var globalAttachment = this.writer.globals.Single().attachments.Single();
+
+            Assert.That(globalAttachment.name, Is.EqualTo(expectedFileName));
+            Assert.That(globalAttachment.type, Is.EqualTo("text/plain"));
+            Assert.That(globalAttachment.source, Does.EndWith(".txt"));
+            Assert.That(this.writer.attachments.Single().Content, Is.EqualTo(content));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Test]
+    public void GlobalErrorFromExceptionWritesGlobalsChunk()
+    {
+        var error = new InvalidOperationException("boom");
+
+        var timestampBefore = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        AllureApi.AddGlobalError(error);
+        var timestampAfter = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+        var global = this.writer.globals.Single();
+        Assert.That(global.attachments, Is.Empty);
+
+        var globalError = global.errors.Single();
+        Assert.That(globalError.message, Is.EqualTo("boom"));
+        Assert.That(globalError.trace, Does.Contain(nameof(InvalidOperationException)));
+        Assert.That(
+            globalError.timestamp,
+            Is.GreaterThanOrEqualTo(timestampBefore)
+                .And.LessThanOrEqualTo(timestampAfter));
+    }
+
+    [Test]
+    public void GlobalErrorFromMessageWritesMessageOnly()
+    {
+        AllureApi.AddGlobalError("boom");
+
+        var globalError = this.writer.globals.Single().errors.Single();
+        Assert.That(globalError.message, Is.EqualTo("boom"));
+        Assert.That(globalError.trace, Is.Null);
+        Assert.That(globalError.timestamp, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void GlobalErrorFromStatusDetailsPreservesProvidedFields()
+    {
+        var details = new StatusDetails
+        {
+            message = "boom",
+            trace = "stack",
+            known = true,
+            muted = true,
+            flaky = true
+        };
+
+        AllureApi.AddGlobalError(details);
+
+        var globalError = this.writer.globals.Single().errors.Single();
+        Assert.That(globalError.message, Is.EqualTo("boom"));
+        Assert.That(globalError.trace, Is.EqualTo("stack"));
+        Assert.That(globalError.known, Is.True);
+        Assert.That(globalError.muted, Is.True);
+        Assert.That(globalError.flaky, Is.True);
+    }
+
+    [Test]
+    public void GlobalCallsProduceSeparateChunks()
+    {
+        AllureApi.AddGlobalError("one");
+        AllureApi.AddGlobalError("two");
+
+        var globals = this.writer.globals;
+
+        Assert.That(globals, Has.Count.EqualTo(2));
+        Assert.That(globals.All(g => g.errors.Count == 1));
+        Assert.That(
+            globals.Select(g => g.errors[0].message),
+            Is.EquivalentTo(["one", "two"]));
+    }
+
+    [Test]
+    public void GlobalApisWorkWithoutActiveTestContext()
+    {
+        AllureApi.AddGlobalAttachment("global", "text/plain", [1], ".txt");
+        AllureApi.AddGlobalError("boom");
+
+        Assert.That(this.writer.attachments, Has.One.Items);
+        Assert.That(this.writer.globals, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void GlobalApisDoNotMutateCurrentTestAttachments()
+    {
+        this.lifecycle.StartTestCase(new() { uuid = "1", fullName = "n" });
+
+        AllureApi.AddGlobalAttachment("global", "text/plain", [1], ".txt");
+
+        Assert.That(this.Context.CurrentTest.attachments, Is.Empty);
+        Assert.That(this.writer.globals, Has.One.Items);
+    }
+}

--- a/tests/Allure.Net.Commons.Tests/UserAPITests/AttributeTests/AttachmentFileTests.cs
+++ b/tests/Allure.Net.Commons.Tests/UserAPITests/AttributeTests/AttachmentFileTests.cs
@@ -179,6 +179,35 @@ class AttachmentFileTests : AllureApiTestFixture
         Assert.That(() => this.AttachWithFailedFormatter(new()), Throws.Nothing);
     }
 
+    [Test]
+    public void CreatesGlobalFileAttachmentIfConfiguredWithoutContext()
+    {
+        this.lifecycle.StopTestCase();
+        this.lifecycle.WriteTestCase();
+
+        this.AttachGlobalByFileInfo();
+
+        var globals = this.writer.globals;
+        Assert.That(globals, Has.One.Items);
+
+        var globalAttachments = globals[0].attachments;
+        Assert.That(globalAttachments, Has.One.Items);
+
+        var globalAttachment = globalAttachments[0];
+        Assert.That(globalAttachment.name, Is.EqualTo("foo"));
+        Assert.That(globalAttachment.type, Is.Null);
+    }
+
+    [Test]
+    public void CreatesGlobalFileAttachmentInsteadOfTestAttachmentIfConfigured()
+    {
+        this.AttachGlobalByFileInfo();
+
+        Assert.That(this.testResult.attachments, Is.Empty);
+        Assert.That(this.writer.globals, Has.One.Items);
+        Assert.That(this.writer.globals[0].attachments, Has.One.Items);
+    }
+
     [AllureAttachmentFile]
     string AttachByStringPath() => this.CreateFile("foo", [1,2,3]).FullName;
 
@@ -219,6 +248,9 @@ class AttachmentFileTests : AllureApiTestFixture
         await Task.Yield();
         return this.CreateFile("foo.baz", [1, 2, 3]);
     }
+
+    [AllureAttachmentFile(Global = true)]
+    FileInfo AttachGlobalByFileInfo() => this.CreateFile("foo", [1, 2, 3]);
 
     class InterpolationStub
     {

--- a/tests/Allure.Net.Commons.Tests/UserAPITests/AttributeTests/AttachmentTests.cs
+++ b/tests/Allure.Net.Commons.Tests/UserAPITests/AttributeTests/AttachmentTests.cs
@@ -243,6 +243,35 @@ class AttachmentTests : AllureApiTestFixture
         Assert.That(() => AttachFailedFormatter(new()), Throws.Nothing);
     }
 
+    [Test]
+    public void CreatesGlobalAttachmentIfConfiguredWithoutContext()
+    {
+        this.lifecycle.StopTestCase();
+        this.lifecycle.WriteTestCase();
+
+        AttachGlobalString();
+
+        var globals = this.writer.globals;
+        Assert.That(globals, Has.One.Items);
+
+        var globalAttachments = globals[0].attachments;
+        Assert.That(globalAttachments, Has.One.Items);
+
+        var globalAttachment = globalAttachments[0];
+        Assert.That(globalAttachment.name, Is.EqualTo(nameof(AttachGlobalString)));
+        Assert.That(globalAttachment.type, Is.EqualTo("text/plain"));
+    }
+
+    [Test]
+    public void CreatesGlobalAttachmentInsteadOfTestAttachmentIfConfigured()
+    {
+        AttachGlobalString();
+
+        Assert.That(this.testResult.attachments, Is.Empty);
+        Assert.That(this.writer.globals, Has.One.Items);
+        Assert.That(this.writer.globals[0].attachments, Has.One.Items);
+    }
+
     [AllureAttachment]
     static byte[] AttachByteArray() => [1, 2, 3];
 
@@ -305,6 +334,9 @@ class AttachmentTests : AllureApiTestFixture
         await Task.Yield();
         return "Lorem Ipsum";
     }
+
+    [AllureAttachment(Global = true)]
+    static string AttachGlobalString() => "Lorem Ipsum";
 
     class InterpolationStub
     {


### PR DESCRIPTION
### Context

Allure Report 3.2.0 has introduced global attachments and errors: report-wide information that is not tied to a particular test.

This PR extends the Allure API to allow producing global errors and attachments at runtime.

### API changes

#### 1. New `AddGlobalAttachment` function (3 overloads):

  - `AddGlobalAttachment(string name, string type, string path)`
  - `AddGlobalAttachment(string name, string type, byte[] content, string fileExtension = "")`
  - `AddGlobalAttachment(string path, string? name = null)`

Examples:

```csharp
AllureApi.AddGlobalAttachment("machine-log", "text/plain", logBytes, ".log");
```

```csharp
AllureApi.AddGlobalAttachment("machine-log", "text/plain", logFilePath);
```

#### 2. New `AddGlobalError` function (3 overloads):

  - `AddGlobalError(Exception error)`
  - `AddGlobalError(string message)`
  - `AddGlobalError(StatusDetails statusDetails)`

Examples:

```csharp
try
{
    // ...
}
catch (Exception e)
{
    AllureApi.AddGlobalError(e);
}
```

```csharp
AllureApi.AddGlobalError("A critical error has occured. The test process will be terminated");
```

```csharp
AllureApi.AddGlobalError(new StatusDetails
{
    message = "Global teardown failed",
    trace = "System.InvalidOperationException: teardown failure\n   at Demo.Teardown()",
});
```

#### 3. New `Global` property for `[AllureAttachment]` and `[AllureAttachmentFile]`

  - `bool Global { get; init; }`

If set to `true`, emits a global attachment instead of a test/step/fixture-scoped one. Global attachments don't require a test or fixture to run.

Examples:

```csharp
[AllureAttachment(Global = true)]
public static string DumpState() => "state";
```

```csharp
[AllureAttachmentFile(Global = true)]
public static FileInfo ExportArtifact() => new FileInfo("artifact.zip");
```

### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
