### PR TITLE
Fix trusted publishing configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
         uses: NuGet/login@v1
         id: login
         with:
-          user: qameta
+          user: baev
 
       - name: 'Publish the packages to NuGet'
         shell: pwsh


### PR DESCRIPTION
### Context

During 2.15.0 publishing, the following error occurred (see [here](https://github.com/allure-framework/allure-csharp/actions/runs/24901917156/job/73185059793)):

```
Token exchange failed (HTTP 401) at https://www.nuget.org/api/v2/token. Make sure you are using the username of the policy creator, not the policy owner: No matching trust policy owned by user 'qameta' was found.
```

Following the advice, this PR changes the `user` argument from the package owner to the trusted policy creator.
