### PR TITLE
Fix path pattern for `dotnet nuget push`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,6 @@ name: Publish
 env:
   SOLUTION_PATH: allure-csharp.slnx
   BUILD_CONFIGURATION: 'Publish'
-  PACKAGE_OUTPUT_PATH: './artifacts/package/release'
 
 on:
   release:
@@ -78,6 +77,6 @@ jobs:
       - name: 'Publish the packages to NuGet'
         shell: pwsh
         run: |
-          dotnet nuget push "${{ env.PACKAGE_OUTPUT_PATH }}/*.nupkg" `
+          dotnet nuget push ".\artifacts\package\release\*.nupkg" `
             --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
             --source "https://api.nuget.org/v3/index.json"


### PR DESCRIPTION
### Context

The PR fixes the `File does not exist (./artifacts/package/release/*.nupkg)` error in the publishing pipeline.

The reason was that due to `/` path separators, the path provided to `dotnet nuget push` was treated as a literal path instead of a path pattern. Changing path separators from `/` to `\` fixes the problem.
