### PR TITLE
feat: Add Allure.TestingPlatform MTP core (MMVP) #554

### DIFF
--- a/allure-csharp.slnx
+++ b/allure-csharp.slnx
@@ -60,6 +60,9 @@
     <Project Path="src/Allure.SpecFlow/Allure.SpecFlow.csproj">
       <BuildType Solution="Publish|*" Project="Release" />
     </Project>
+    <Project Path="src/Allure.TestingPlatform/Allure.TestingPlatform.csproj">
+      <BuildType Solution="Publish|*" Project="Release" />
+    </Project>
     <Project Path="src/Allure.Xunit/Allure.Xunit.csproj">
       <BuildType Solution="Publish|*" Project="Release" />
     </Project>

--- a/allure-csharp.slnx
+++ b/allure-csharp.slnx
@@ -83,6 +83,9 @@
     <Project Path="tests/Allure.SpecFlow.Tests/Allure.SpecFlow.Tests.csproj">
       <Build Solution="Publish|*" Project="false" />
     </Project>
+    <Project Path="tests/Allure.TestingPlatform.Tests/Allure.TestingPlatform.Tests.csproj">
+      <Build Solution="Publish|*" Project="false" />
+    </Project>
     <Project Path="tests/Allure.Reqnroll.Tests.Samples/Allure.Reqnroll.Tests.Samples.csproj">
       <Build Solution="Publish|*" Project="false" />
     </Project>

--- a/src/Allure.TestingPlatform/Allure.TestingPlatform.csproj
+++ b/src/Allure.TestingPlatform/Allure.TestingPlatform.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <PackageId>Allure.TestingPlatform</PackageId>
+        <RootNamespace>Allure.TestingPlatform</RootNamespace>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <Authors>Allure Framework Contributors</Authors>
+        <Description>Framework-agnostic Allure adapter for Microsoft.Testing.Platform. Consumes MTP messages and drives Allure.Net.Commons; intended as the foundation for framework-specific adapters (xUnit.v3, etc.).</Description>
+        <PackageIcon>Allure-Color.png</PackageIcon>
+        <PackageTags>$(PackageTags) microsoft-testing-platform mtp</PackageTags>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="README.md" Pack="true" PackagePath="\" />
+        <None Include="../../img/Allure-Color.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Testing.Platform" Version="1.4.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Allure.Net.Commons\Allure.Net.Commons.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Allure.TestingPlatform/AllureDataConsumer.cs
+++ b/src/Allure.TestingPlatform/AllureDataConsumer.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Allure.Net.Commons;
+using Allure.Net.Commons.Functions;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using Microsoft.Testing.Platform.Extensions.TestHost;
+
+namespace Allure.TestingPlatform;
+
+/// <summary>
+/// Consumes Microsoft.Testing.Platform <see cref="TestNodeUpdateMessage"/>s
+/// and projects them onto Allure's <see cref="AllureLifecycle"/>.
+/// </summary>
+/// <remarks>
+/// Minimal viable scope: maps terminal test states (Passed / Failed / Skipped
+/// / Error / Timeout / Cancelled) to a single Schedule → Start → Update →
+/// Stop → Write sequence per test. <c>InProgress</c> updates are ignored —
+/// timing therefore reflects when the consumer processed the terminal
+/// message, not the test's actual wall-clock duration. This will be addressed
+/// in a follow-up PR by reading <see cref="TimingProperty"/>.
+/// </remarks>
+public sealed class AllureDataConsumer : IDataConsumer
+{
+    static readonly Type[] s_consumed = [typeof(TestNodeUpdateMessage)];
+
+    readonly AllureLifecycle _lifecycle;
+    readonly object _sequenceLock = new();
+
+    public AllureDataConsumer() : this(AllureLifecycle.Instance) { }
+
+    internal AllureDataConsumer(AllureLifecycle lifecycle)
+    {
+        _lifecycle = lifecycle;
+    }
+
+    public string Uid => "Allure.TestingPlatform";
+
+    public string Version => typeof(AllureDataConsumer).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+
+    public string DisplayName => "Allure Report";
+
+    public string Description => "Writes Allure result files for tests reported through Microsoft.Testing.Platform.";
+
+    public Type[] DataTypesConsumed => s_consumed;
+
+    public Task<bool> IsEnabledAsync() => Task.FromResult(true);
+
+    public Task ConsumeAsync(
+        IDataProducer dataProducer,
+        IData value,
+        CancellationToken cancellationToken)
+    {
+        if (value is TestNodeUpdateMessage update)
+        {
+            HandleUpdate(update);
+        }
+        return Task.CompletedTask;
+    }
+
+    void HandleUpdate(TestNodeUpdateMessage update)
+    {
+        var node = update.TestNode;
+        var state = node.Properties.OfType<TestNodeStateProperty>().LastOrDefault();
+        if (state is null || state is InProgressTestNodeStateProperty)
+        {
+            return;
+        }
+
+        var (status, message, trace) = MapState(state);
+
+        var testResult = new TestResult
+        {
+            uuid = IdFunctions.CreateUUID(),
+            name = node.DisplayName,
+            fullName = node.Uid.Value,
+            historyId = node.Uid.Value,
+        };
+
+        lock (_sequenceLock)
+        {
+            _lifecycle.StartTestCase(testResult);
+            _lifecycle.UpdateTestCase(tr =>
+            {
+                tr.status = status;
+                if (message is not null || trace is not null)
+                {
+                    tr.statusDetails ??= new StatusDetails();
+                    tr.statusDetails.message = message;
+                    tr.statusDetails.trace = trace;
+                }
+            });
+            _lifecycle.StopTestCase();
+            _lifecycle.WriteTestCase();
+        }
+    }
+
+    static (Status status, string? message, string? trace) MapState(TestNodeStateProperty state) =>
+        state switch
+        {
+            PassedTestNodeStateProperty => (Status.passed, null, null),
+            SkippedTestNodeStateProperty s => (Status.skipped, s.Explanation, null),
+            FailedTestNodeStateProperty f => (Status.failed, f.Exception?.Message, f.Exception?.StackTrace),
+            ErrorTestNodeStateProperty e => (Status.broken, e.Exception?.Message, e.Exception?.StackTrace),
+            TimeoutTestNodeStateProperty t => (Status.broken, t.Exception?.Message ?? "Test timed out", t.Exception?.StackTrace),
+            CancelledTestNodeStateProperty c => (Status.broken, c.Exception?.Message ?? "Test cancelled", c.Exception?.StackTrace),
+            _ => (Status.none, null, null),
+        };
+}

--- a/src/Allure.TestingPlatform/README.md
+++ b/src/Allure.TestingPlatform/README.md
@@ -1,0 +1,34 @@
+# Allure.TestingPlatform
+
+Framework-agnostic Allure adapter for [Microsoft.Testing.Platform][mtp]. It
+consumes MTP messages (`TestNodeUpdateMessage`) and drives `AllureLifecycle`
+from `Allure.Net.Commons`, producing standard Allure result files.
+
+This package is the foundation for framework-specific adapters (xUnit.v3,
+NUnit-on-MTP, etc.); those layers add framework-specific enrichment (traits →
+labels, parameter formatting, fixture mapping) on top of the lifecycle handled
+here.
+
+## Status
+
+**Minimal viable scaffold.** Currently maps the test happy path
+(`InProgress` / `Passed` / `Failed` / `Skipped`) to Allure test results.
+Steps, fixtures, attachments, parameters and labels will follow in subsequent
+PRs.
+
+## Usage
+
+In your MTP-based test project's `Program.cs`:
+
+```csharp
+using Allure.TestingPlatform;
+using Microsoft.Testing.Platform.Builder;
+
+var builder = await TestApplication.CreateBuilderAsync(args);
+// register your test framework's MTP integration first, e.g. builder.AddXunit()
+builder.AddAllure();
+using var app = await builder.BuildAsync();
+return await app.RunAsync();
+```
+
+[mtp]: https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro

--- a/src/Allure.TestingPlatform/TestApplicationBuilderExtensions.cs
+++ b/src/Allure.TestingPlatform/TestApplicationBuilderExtensions.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.Testing.Platform.Builder;
+
+namespace Allure.TestingPlatform;
+
+/// <summary>
+/// Wires the Allure data consumer into a Microsoft.Testing.Platform host.
+/// </summary>
+public static class TestApplicationBuilderExtensions
+{
+    /// <summary>
+    /// Registers the Allure data consumer so the host writes Allure result
+    /// files for every reported test.
+    /// </summary>
+    public static ITestApplicationBuilder AddAllure(this ITestApplicationBuilder builder)
+    {
+        if (builder is null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        builder.TestHost.AddDataConsumer(_ => new AllureDataConsumer());
+        return builder;
+    }
+}

--- a/tests/Allure.TestingPlatform.Tests/Allure.TestingPlatform.Tests.csproj
+++ b/tests/Allure.TestingPlatform.Tests/Allure.TestingPlatform.Tests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="NUnit" Version="4.4.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Allure.TestingPlatform\Allure.TestingPlatform.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Allure.TestingPlatform.Tests/AllureDataConsumerTests.cs
+++ b/tests/Allure.TestingPlatform.Tests/AllureDataConsumerTests.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using Allure.TestingPlatform;
+using Microsoft.Testing.Platform.Extensions.Messages;
+using NUnit.Framework;
+
+namespace Allure.TestingPlatform.Tests;
+
+[TestFixture]
+public class AllureDataConsumerTests
+{
+    [Test]
+    public void DataTypesConsumed_includes_TestNodeUpdateMessage()
+    {
+        var consumer = new AllureDataConsumer();
+
+        Assert.That(consumer.DataTypesConsumed, Has.Member(typeof(TestNodeUpdateMessage)));
+    }
+
+    [Test]
+    public async Task IsEnabledAsync_returns_true()
+    {
+        var consumer = new AllureDataConsumer();
+
+        Assert.That(await consumer.IsEnabledAsync(), Is.True);
+    }
+
+    [Test]
+    public void Extension_metadata_is_populated()
+    {
+        var consumer = new AllureDataConsumer();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(consumer.Uid, Is.EqualTo("Allure.TestingPlatform"));
+            Assert.That(consumer.DisplayName, Is.Not.Empty);
+            Assert.That(consumer.Description, Is.Not.Empty);
+            Assert.That(consumer.Version, Is.Not.Empty);
+        });
+    }
+}


### PR DESCRIPTION
### Context

Following up on the discussion in [#554](https://github.com/allure-framework/allure-csharp/issues/554) and feedback from the closed [#654](https://github.com/allure-framework/allure-csharp/pull/654).

This is a **very small, reviewable first piece** implementing an MTP-first core as suggested by the maintainer.

### What’s included
- New `Allure.TestingPlatform` package (framework-agnostic, targets `net8.0`)
- `AllureDataConsumer` implementing `IDataConsumer` – handles `TestNodeUpdateMessage` and maps terminal states (`Passed`/`Failed`/`Skipped`/`Error`/`Timeout`/`Cancelled`) to Allure lifecycle (`Schedule → Start → Update → Stop → Write`)
- `TestApplicationBuilderExtensions.AddAllure()` extension method for easy registration
- Basic NUnit smoke tests verifying consumer registration and extension metadata

### Intentional limitations (for follow-up PRs)
- No test duration mapping yet (durations ≈ 0)
- No labels, parameters, attachments, steps, or fixtures
- No MSBuild `.props` auto-registration (manual `builder.AddAllure()` for now)
- No xUnit.v3 specific layer (planned as next piece)

This matches the requested approach: **MTP-first**, small incremental PRs, and discussion before heavy work.

cc @delatrie

---

**Checklist**
- [x] [Sign Allure CLA](https://cla-assistant.io/accept/allure-framework/allure2)
- [x] Provide unit tests