### PR TITLE
Respect [AllureName] by titlePath of xUnit tests

### DIFF
--- a/src/Allure.Net.Commons/Functions/IdFunctions.cs
+++ b/src/Allure.Net.Commons/Functions/IdFunctions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Allure.Net.Commons.Attributes;
 using Newtonsoft.Json;
 
 namespace Allure.Net.Commons.Functions;
@@ -30,6 +31,7 @@ public static class IdFunctions
     /// <item>type parameters (for generic type definitions)</item>
     /// <item>type arguments (for constructed generic types)</item>
     /// </list>
+    /// The type node can be renamed by applying <see cref="AllureNameAttribute"/> to the class.
     /// </remarks>
     public static List<string> CreateTitlePath(Type type)
     {
@@ -42,14 +44,15 @@ public static class IdFunctions
 
         var assemblyName = type.Assembly.GetName().Name;
         var namespaceParts = (type.Namespace ?? "").Split('.').Where(s => s.Length > 0);
-        var typeName = string.Join("+", ExpandNestness(type).Reverse());
-        var typeArguments = type.GetGenericArguments();
-        var typeArgumentsText = SerializeTypeParameterTypeList(typeArguments);
+        var typeNode = type.GetCustomAttribute<AllureNameAttribute>()?.Name
+            ?? (string.Join("+", ExpandNestness(type).Reverse()) +
+                SerializeTypeParameterTypeList(
+                    type.GetGenericArguments()));
 
         return [
             assemblyName,
             .. namespaceParts,
-            typeName + typeArgumentsText,
+            typeNode,
         ];
     }
 

--- a/src/Allure.Net.Commons/Functions/IdFunctions.cs
+++ b/src/Allure.Net.Commons/Functions/IdFunctions.cs
@@ -57,6 +57,35 @@ public static class IdFunctions
     }
 
     /// <summary>
+    /// Creates a titlePath: a path to a test class in a tree of test results.
+    /// </summary>
+    /// <param name="method">A test method</param>
+    /// <remarks>
+    /// A titlePath consists of:
+    /// <list type="bullet">
+    /// <item>assembly name</item>
+    /// <item>elements of namespace</item>
+    /// <item>name of type (including its declaring types, if any)</item>
+    /// <item>type parameters (for generic type definitions)</item>
+    /// <item>type arguments (for constructed generic types)</item>
+    /// <item>method name with type parameters and parameter types (for parameterized method)</item>
+    /// </list>
+    /// The type and method nodes can be renamed by applying <see cref="AllureNameAttribute"/>.
+    /// </remarks>
+    public static List<string> CreateTitlePath(MethodInfo method)
+    {
+        var titlePath = CreateTitlePath(method.DeclaringType);
+        if (method.GetParameters().Length > 0)
+        {
+            titlePath.Add(
+                method.GetCustomAttribute<AllureNameAttribute>()?.Name
+                    ?? GetMethodId(method)
+            );
+        }
+        return titlePath;
+    }
+
+    /// <summary>
     /// Creates a name that uniquely identifies a given type.
     /// </summary>
     /// <remarks>

--- a/tests/Allure.Net.Commons.Tests/FunctionTests/TitlePathTests.cs
+++ b/tests/Allure.Net.Commons.Tests/FunctionTests/TitlePathTests.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using Allure.Net.Commons.Attributes;
 using Allure.Net.Commons.Functions;
 using NUnit.Framework;
 
@@ -93,6 +93,17 @@ class TitlePathTests
                 "Allure.Net.Commons.Tests:Allure.Net.Commons.Tests.FunctionTests.TitlePathTests+MyClass]]",
         TestName = "Nested constructed generic class - complex"
     )]
+    [TestCase(
+        typeof(ClassWithAllureName<int, string>),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "Foo",
+        TestName = "Class with [AllureName]"
+    )]
     public void TestTitlePathByClass(Type targetClass, params string[] expectedTitlePath)
     {
         Assert.That(
@@ -121,4 +132,7 @@ class TitlePathTests
     }
 
     class MyClass<T1, T2> { }
+
+    [AllureName("Foo")]
+    class ClassWithAllureName<T1, T2> { }
 }

--- a/tests/Allure.Net.Commons.Tests/FunctionTests/TitlePathTests.cs
+++ b/tests/Allure.Net.Commons.Tests/FunctionTests/TitlePathTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using Allure.Net.Commons.Attributes;
 using Allure.Net.Commons.Functions;
 using NUnit.Framework;
@@ -112,24 +113,71 @@ class TitlePathTests
         );
     }
 
+    [TestCase(
+        typeof(MyClass),
+        nameof(MyClass.ParameterlessMethod),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass",
+        TestName = "Parameterless method"
+    )]
+    [TestCase(
+        typeof(MyClass),
+        nameof(MyClass.ParameterizedMethod),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass",
+        "ParameterizedMethod(System.Int32)",
+        TestName = "Parameterized method - int"
+    )]
+    [TestCase(
+        typeof(MyClass),
+        nameof(MyClass.ParameterizedMethodWithAllureName),
+        "Allure.Net.Commons.Tests",
+        "Allure",
+        "Net",
+        "Commons",
+        "Tests",
+        "FunctionTests",
+        "TitlePathTests+MyClass",
+        "Foo",
+        TestName = "Method with [AllureName]"
+    )]
+    public void TestTitlePathOfParameterizedMethod(
+        Type targetClass,
+        string targetMethodName,
+        params string[] expectedTitlePath
+    )
+    {
+        var method = targetClass.GetMethod(
+            targetMethodName,
+            BindingFlags.Instance | BindingFlags.NonPublic
+        );
+
+        var actualTitlePath = IdFunctions.CreateTitlePath(method);
+
+        Assert.That(actualTitlePath, Is.EqualTo(expectedTitlePath));
+    }
+
     class MyClass
     {
         internal void ParameterlessMethod() { }
-        internal void MethodWithParameterOfBuiltInType(int _) { }
-        internal void MethodWithParameterOfUserType(MyClass _) { }
-        internal void MethodWithTwoParameters(int _, MyClass __) { }
-        internal void MethodWithRefParameter(ref int _) { }
-        internal void MethodWithGenericParameter<T>() { }
-        internal void MethodWithArgumentOfGenericType<T>(T _) { }
-        internal void MethodWithArgumentOfTypeParametrizedByGenericType<T>(Dictionary<int, T> _) { }
-        internal void MethodWithArgumentOfGenericUserType<T>(MyClass<T> _) { }
+
+        internal void ParameterizedMethod(int _) { }
+
+        [AllureName("Foo")]
+        internal void ParameterizedMethodWithAllureName(int _) { }
     }
 
-    class MyClass<T>
-    {
-        public class Nested<G> { }
-        internal void GenericMethodOfGenericClass<V>(List<T> _, List<V> __) { }
-    }
+    class MyClass<T> { }
 
     class MyClass<T1, T2> { }
 


### PR DESCRIPTION
### Context

The PR allows renaming the type node of a titlePath created via `CreateTitlePath` by applying `[AllureName(...)]`, which helps avoid non-user-friendly type names (such as types with generic parameters or nested types).

Currently, this only affects xUnit.net, as Allure.NUnit uses NUnit-provided names for titlePath, and Allure.Reqnroll uses feature/scenario names.

Additionally, the PR adds a new `CreateTitlePath` overload that takes an instance of `MethodInfo`. This overload also respects `[AllureName]` at the type and method levels.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
