### PR TITLE
Make AllureLifecycle and AllureConfiguration constructors public

### DIFF
--- a/src/Allure.Net.Commons/AllureLifecycle.cs
+++ b/src/Allure.Net.Commons/AllureLifecycle.cs
@@ -109,6 +109,38 @@ public class AllureLifecycle
     }
 
     /// <summary>
+    /// Creates an instance of Allure lifecycle.
+    /// </summary>
+    /// <param name="config">A configuration to use.</param>
+    /// <param name="writer">A writer to emit the results to.</param>
+    public AllureLifecycle(AllureConfiguration config, IAllureResultsWriter writer)
+    {
+        this.JsonConfiguration = JObject.FromObject(config).ToString();
+        this.AllureConfiguration = config;
+        this.writer = writer;
+        this.lazyTestPlan = new(AllureTestPlan.FromEnvironment);
+    }
+
+    /// <summary>
+    /// Creates an instance of Allure lifecycle.
+    /// </summary>
+    /// <param name="config">A configuration to use.</param>
+    /// <param name="writer">A writer to emit the results to.</param>
+    /// <param name="typeFormatters">A collection of type formatters to use for parameter serialization.</param>
+    public AllureLifecycle(
+        AllureConfiguration config,
+        IAllureResultsWriter writer,
+        Dictionary<Type, ITypeFormatter> typeFormatters
+    )
+    {
+        this.JsonConfiguration = JObject.FromObject(config).ToString();
+        this.AllureConfiguration = config;
+        this.writer = writer;
+        this.lazyTestPlan = new(AllureTestPlan.FromEnvironment);
+        this.typeFormatters = typeFormatters;
+    }
+
+    /// <summary>
     /// The JSON representation of the current Allure configuration.
     /// </summary>
     public string JsonConfiguration { get; private set; }

--- a/src/Allure.Net.Commons/Configuration/AllureConfiguration.cs
+++ b/src/Allure.Net.Commons/Configuration/AllureConfiguration.cs
@@ -7,12 +7,12 @@ namespace Allure.Net.Commons.Configuration
 {
     public class AllureConfiguration
     {
-        internal AllureConfiguration()
+        public AllureConfiguration()
         {
         }
 
         [JsonConstructor]
-        protected AllureConfiguration(string title, string directory, HashSet<string> links)
+        public AllureConfiguration(string title, string directory, HashSet<string> links)
         {
             Title = title ?? Title;
             Directory = Path.GetFullPath(directory ?? Directory);
@@ -21,7 +21,7 @@ namespace Allure.Net.Commons.Configuration
 
         public string Title { get; init; }
         public string Directory { get; init; } = Path.GetFullPath(AllureConstants.DEFAULT_RESULTS_FOLDER);
-        public HashSet<string> Links { get; } = [];
+        public HashSet<string> Links { get; init; } = [];
         public List<string> FailExceptions { get; set; }
         public bool UseLegacyIds { get; set; } = false;
         public bool IndentOutput { get; set; } = false;

--- a/src/Allure.Net.Commons/Functions/ModelFunctions.cs
+++ b/src/Allure.Net.Commons/Functions/ModelFunctions.cs
@@ -135,7 +135,14 @@ public static class ModelFunctions
     /// configuration property.
     /// </summary>
     public static IEnumerable<Label> EnumerateGlobalLabels() =>
-        from kv in Config.GlobalLabels ?? []
+        EnumerateGlobalLabels(Config);
+
+    /// <summary>
+    /// Returns a sequence of labels defined by the <c>globalLabels</c>
+    /// configuration property.
+    /// </summary>
+    public static IEnumerable<Label> EnumerateGlobalLabels(AllureConfiguration config) =>
+        from kv in config.GlobalLabels ?? []
         where !string.IsNullOrEmpty(kv.Key) && !string.IsNullOrEmpty(kv.Value)
         select new Label { name = kv.Key, value = kv.Value };
 
@@ -159,7 +166,7 @@ public static class ModelFunctions
     /// <returns>A sequence of Allure parameters.</returns>
     public static IEnumerable<Parameter> CreateParameters(
         IEnumerable<ParameterInfo> parameters,
-        IEnumerable<object> values,
+        IEnumerable<object?> values,
         IReadOnlyDictionary<Type, ITypeFormatter> formatters
     )
         => CreateParameters(
@@ -194,7 +201,7 @@ public static class ModelFunctions
     public static IEnumerable<Parameter> CreateParameters(
         IEnumerable<string> parameterNames,
         IEnumerable<AllureParameterAttribute?> attributes,
-        IEnumerable<object> values,
+        IEnumerable<object?> values,
         IReadOnlyDictionary<Type, ITypeFormatter> formatters
     )
         => parameterNames

--- a/src/Allure.Net.Commons/Functions/ModelFunctions.cs
+++ b/src/Allure.Net.Commons/Functions/ModelFunctions.cs
@@ -25,10 +25,10 @@ public static class ModelFunctions
     /// <param name="e">The exception to check.</param>
     public static bool IsKnownError(IEnumerable<string> knownErrorBases, Exception e) =>
         knownErrorBases
-            .Intersect(
+            ?.Intersect(
                 GetExceptionClassChain(e)
             )
-            .Any();
+            ?.Any() == true;
 
     /// <summary>
     /// Returns a <see cref="Status.failed"/> if a given exception represents

--- a/tests/Allure.Net.Commons.Tests/AllureLifeCycleTest.cs
+++ b/tests/Allure.Net.Commons.Tests/AllureLifeCycleTest.cs
@@ -102,7 +102,7 @@ namespace Allure.Net.Commons.Tests
         public void BeforeFixtureMayOverlapsWithTest()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             var container = new TestResultContainer
             {
                 uuid = Guid.NewGuid().ToString()
@@ -142,7 +142,7 @@ namespace Allure.Net.Commons.Tests
         public async Task ContextCapturingTest()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             AllureContext context = null, modifiedContext = null;
             await Task.Factory.StartNew(() =>
             {
@@ -167,7 +167,7 @@ namespace Allure.Net.Commons.Tests
         public async Task AsyncContextCapturingTest()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             AllureContext context = null;
             await Task.Factory.StartNew(() =>
             {
@@ -194,7 +194,7 @@ namespace Allure.Net.Commons.Tests
         public async Task ContextCapturingHasNoEffectIfContextIsNull()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             await Task.Factory.StartNew(() =>
             {
                 lifecycle.StartTestCase(new()
@@ -214,7 +214,7 @@ namespace Allure.Net.Commons.Tests
         public async Task AsyncContextCapturingHasNoEffectIfContextIsNull()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             await Task.Factory.StartNew(() =>
             {
                 lifecycle.StartTestCase(new()
@@ -235,7 +235,7 @@ namespace Allure.Net.Commons.Tests
         public void HistoryAndTestCaseIdsAreSetAfterStop()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             lifecycle.StartTestCase(new()
             {
                 uuid = "uuid",
@@ -256,7 +256,7 @@ namespace Allure.Net.Commons.Tests
         public void HistoryAndTestCaseIdsAreNotOverwrittenAfterStop()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             lifecycle.StartTestCase(new()
             {
                 uuid = "uuid",
@@ -275,7 +275,7 @@ namespace Allure.Net.Commons.Tests
         public void EmptyTestContainerNotWritten()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             lifecycle.StartTestContainer(new() { uuid = "foo" });
             lifecycle.StopTestContainer();
 
@@ -288,7 +288,7 @@ namespace Allure.Net.Commons.Tests
         public void ContainerWithBeforeFixtureIsWritten()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             lifecycle.StartTestContainer(new() { uuid = "foo" });
             lifecycle.StartBeforeFixture(new());
             lifecycle.StopFixture();
@@ -303,7 +303,7 @@ namespace Allure.Net.Commons.Tests
         public void ContainerWithAfterFixtureIsWritten()
         {
             var writer = new InMemoryResultsWriter();
-            var lifecycle = new AllureLifecycle(_ => writer);
+            var lifecycle = new AllureLifecycle(new(), writer);
             lifecycle.StartTestContainer(new() { uuid = "foo" });
             lifecycle.StartAfterFixture(new());
             lifecycle.StopFixture();

--- a/tests/Allure.Net.Commons.Tests/ConcurrencyTests.cs
+++ b/tests/Allure.Net.Commons.Tests/ConcurrencyTests.cs
@@ -19,7 +19,7 @@ namespace Allure.Net.Commons.Tests
         public void SetUp()
         {
             this.writer = new InMemoryResultsWriter();
-            this.lifecycle = new AllureLifecycle(_ => this.writer);
+            this.lifecycle = new AllureLifecycle(new(), writer);
         }
 
         [Test]

--- a/tests/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/ErrorStatusTests.cs
+++ b/tests/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/ErrorStatusTests.cs
@@ -1,0 +1,248 @@
+using System;
+using Allure.Net.Commons.Functions;
+using NUnit.Framework;
+
+namespace Allure.Net.Commons.Tests.FunctionTests.ModelFunctionTests;
+
+class ErrorStatusTests
+{
+    [Test]
+    public void ShouldReturnFalseIfKnownErrorsIsNull()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(null, new InvalidOperationException()),
+            Is.False
+        );
+    }
+
+    [Test]
+    public void ShouldReturnFalseIfKnownErrorsIsEmpty()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError([], new InvalidOperationException()),
+            Is.False
+        );
+    }
+
+    [Test]
+    public void ShouldReturnTrueForExactExceptionTypeMatch()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [typeof(InvalidOperationException).FullName],
+                new InvalidOperationException()
+            ),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void ShouldReturnTrueForBaseExceptionTypeMatch()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [typeof(Exception).FullName],
+                new InvalidOperationException()
+            ),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void ShouldReturnTrueForIntermediateBaseTypeMatch()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [typeof(BaseTestException).FullName],
+                new DerivedTestException()
+            ),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void ShouldReturnTrueForImplementedInterfaceMatch()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [typeof(ITestErrorMarker).FullName],
+                new InterfaceTestException()
+            ),
+            Is.True
+        );
+    }
+
+    [Test]
+    public void ShouldReturnFalseIfNoTypeInChainMatches()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [typeof(ArgumentException).FullName],
+                new InvalidOperationException()
+            ),
+            Is.False
+        );
+    }
+
+    [Test]
+    public void ShouldUseFullTypeNameComparison()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [nameof(InvalidOperationException)],
+                new InvalidOperationException()
+            ),
+            Is.False
+        );
+    }
+
+    [Test]
+    public void ShouldBeCaseSensitive()
+    {
+        Assert.That(
+            ModelFunctions.IsKnownError(
+                [typeof(InvalidOperationException).FullName.ToLowerInvariant()],
+                new InvalidOperationException()
+            ),
+            Is.False
+        );
+    }
+
+    [Test]
+    public void ShouldReturnFailedForExactExceptionTypeMatch()
+    {
+        Assert.That(
+            ModelFunctions.ResolveErrorStatus(
+                [typeof(InvalidOperationException).FullName],
+                new InvalidOperationException()
+            ),
+            Is.EqualTo(Status.failed)
+        );
+    }
+
+    [Test]
+    public void ShouldReturnFailedForBaseExceptionTypeMatch()
+    {
+        Assert.That(
+            ModelFunctions.ResolveErrorStatus(
+                [typeof(Exception).FullName],
+                new InvalidOperationException()
+            ),
+            Is.EqualTo(Status.failed)
+        );
+    }
+
+    [Test]
+    public void ShouldReturnFailedForInterfaceMatch()
+    {
+        Assert.That(
+            ModelFunctions.ResolveErrorStatus(
+                [typeof(ITestErrorMarker).FullName],
+                new InterfaceTestException()
+            ),
+            Is.EqualTo(Status.failed)
+        );
+    }
+
+    [Test]
+    public void ShouldReturnBrokenIfNoMatchFound()
+    {
+        Assert.That(
+            ModelFunctions.ResolveErrorStatus(
+                [typeof(ArgumentException).FullName],
+                new InvalidOperationException()
+            ),
+            Is.EqualTo(Status.broken)
+        );
+    }
+
+    [Test]
+    public void ShouldReturnBrokenIfFailExceptionsIsNull()
+    {
+        Assert.That(
+            ModelFunctions.ResolveErrorStatus(null, new InvalidOperationException()),
+            Is.EqualTo(Status.broken)
+        );
+    }
+
+    [Test]
+    public void ShouldReturnBrokenIfFailExceptionsIsEmpty()
+    {
+        Assert.That(
+            ModelFunctions.ResolveErrorStatus([], new InvalidOperationException()),
+            Is.EqualTo(Status.broken)
+        );
+    }
+
+    [Test]
+    public void ShouldReturnNullIfExceptionIsNull()
+    {
+        Assert.That(ModelFunctions.ToStatusDetails(null), Is.Null);
+    }
+
+    [Test]
+    public void ShouldUseExceptionMessageWhenNotEmpty()
+    {
+        var details = ModelFunctions.ToStatusDetails(
+            new InvalidOperationException("boom")
+        );
+
+        Assert.That(details.message, Is.EqualTo("boom"));
+    }
+
+    [Test]
+    public void ShouldUseExceptionTypeNameWhenMessageIsEmpty()
+    {
+        var details = ModelFunctions.ToStatusDetails(new EmptyMessageException());
+
+        Assert.That(details.message, Is.EqualTo(nameof(EmptyMessageException)));
+    }
+
+    [Test]
+    public void ShouldUseExceptionTypeNameWhenMessageIsNull()
+    {
+        var details = ModelFunctions.ToStatusDetails(new NullMessageException());
+
+        Assert.That(details.message, Is.EqualTo(nameof(NullMessageException)));
+    }
+
+    [Test]
+    public void ShouldSetTraceToExceptionToString()
+    {
+        var error = new InvalidOperationException("boom");
+        var details = ModelFunctions.ToStatusDetails(error);
+
+        Assert.That(details.trace, Is.EqualTo(error.ToString()));
+    }
+
+    [Test]
+    public void ShouldPreserveInnerExceptionDetailsInTrace()
+    {
+        var error = new InvalidOperationException(
+            "outer",
+            new ArgumentException("inner")
+        );
+        var details = ModelFunctions.ToStatusDetails(error);
+
+        Assert.That(details.trace, Does.Contain("outer"));
+        Assert.That(details.trace, Does.Contain("inner"));
+    }
+
+    interface ITestErrorMarker;
+
+    class BaseTestException : Exception;
+
+    class DerivedTestException : BaseTestException;
+
+    class InterfaceTestException : Exception, ITestErrorMarker;
+
+    class EmptyMessageException : Exception
+    {
+        public override string Message => "";
+    }
+
+    class NullMessageException : Exception
+    {
+        public override string Message => null;
+    }
+}

--- a/tests/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/GlobalLabelsTests.cs
+++ b/tests/Allure.Net.Commons.Tests/FunctionTests/ModelFunctionTests/GlobalLabelsTests.cs
@@ -13,7 +13,6 @@ class GlobalLabelsTests
     public void SetUpEnvSource()
     {
         this.config = new();
-        ModelFunctions.Config = this.config;
     }
 
     [TearDown]
@@ -28,7 +27,7 @@ class GlobalLabelsTests
         this.config.GlobalLabels = null;
 
         Assert.That(
-            () => ModelFunctions.EnumerateGlobalLabels().ToList(),
+            () => ModelFunctions.EnumerateGlobalLabels(this.config).ToList(),
             Throws.Nothing
         );
     }
@@ -40,7 +39,7 @@ class GlobalLabelsTests
         this.config.GlobalLabels["baz"] = "qux";
 
         Assert.That(
-            ModelFunctions.EnumerateGlobalLabels(),
+            ModelFunctions.EnumerateGlobalLabels(this.config),
             Is.EquivalentTo(new Label[]
             {
                 new() { name = "foo", value = "bar" },
@@ -54,7 +53,7 @@ class GlobalLabelsTests
     {
         this.config.GlobalLabels["foo"] = null;
 
-        Assert.That(ModelFunctions.EnumerateGlobalLabels(), Is.Empty);
+        Assert.That(ModelFunctions.EnumerateGlobalLabels(this.config), Is.Empty);
     }
 
     [Test]
@@ -62,7 +61,7 @@ class GlobalLabelsTests
     {
         this.config.GlobalLabels["foo"] = "";
 
-        Assert.That(ModelFunctions.EnumerateGlobalLabels(), Is.Empty);
+        Assert.That(ModelFunctions.EnumerateGlobalLabels(this.config), Is.Empty);
     }
 
     [Test]
@@ -70,6 +69,6 @@ class GlobalLabelsTests
     {
         this.config.GlobalLabels[""] = "foo";
 
-        Assert.That(ModelFunctions.EnumerateGlobalLabels(), Is.Empty);
+        Assert.That(ModelFunctions.EnumerateGlobalLabels(this.config), Is.Empty);
     }
 }

--- a/tests/Allure.Net.Commons.Tests/UserAPITests/AllureApiTestFixture.cs
+++ b/tests/Allure.Net.Commons.Tests/UserAPITests/AllureApiTestFixture.cs
@@ -15,7 +15,7 @@ class AllureApiTestFixture
     public void SetUp()
     {
         this.writer = new InMemoryResultsWriter();
-        this.lifecycle = new AllureLifecycle(_ => this.writer);
+        this.lifecycle = new AllureLifecycle(new(), writer);
         AllureApi.CurrentLifecycle = lifecycle;
     }
 


### PR DESCRIPTION
### Context

The PR allows other projects to create instances of AllureLifecycle and AllureConfiguration. The goal is to allow integration packages to define their own initialization routines rather than relying on statically created singletons.

The follow-up work will allow AllureApi to access the result of such initialization, making singletons a non-mandatory default rather than the only available mechanism for tying the API to the lifecycle.

### Extra changes

  - guard against `NullReferenceException` in `IsKnownError`
  - cover `IsKnownError`, `ResolveErrorStatus`, and `ToStatusDetails` with tests

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
