### PR TITLE
Omit empty statusDetails from *-result.json

### DIFF
--- a/src/Allure.Net.Commons/Model/allure2.Designer.cs
+++ b/src/Allure.Net.Commons/Model/allure2.Designer.cs
@@ -221,7 +221,7 @@ namespace Allure.Net.Commons
 
         private Status _status;
 
-        private StatusDetails _statusDetails;
+        private StatusDetails? _statusDetails;
 
         private Stage _stage;
 
@@ -245,7 +245,7 @@ namespace Allure.Net.Commons
             this._parameters = new List<Parameter>();
             this._attachments = new List<Attachment>();
             this._steps = new List<StepResult>();
-            this._statusDetails = new StatusDetails();
+            this._statusDetails = null;
         }
 
         public string name
@@ -272,7 +272,7 @@ namespace Allure.Net.Commons
             }
         }
 
-        public StatusDetails statusDetails
+        public StatusDetails? statusDetails
         {
             get
             {

--- a/src/Allure.Reqnroll/State/AllureReqnrollStateFacade.cs
+++ b/src/Allure.Reqnroll/State/AllureReqnrollStateFacade.cs
@@ -17,7 +17,7 @@ static class AllureReqnrollStateFacade
 
     const string ASSERT_EXC_NUNIT =
         "NUnit.Framework.AssertionException";
-    const string ASSERT_EXC_NUNIT_MULTIPLE = 
+    const string ASSERT_EXC_NUNIT_MULTIPLE =
         "NUnit.Framework.MultipleAssertException";
     const string ASSERT_EXC_XUNIT_NEW = // From v2.4.2 and onward.
         "Xunit.Sdk.IAssertionException";
@@ -190,7 +190,7 @@ static class AllureReqnrollStateFacade
                 break;
             case ScenarioExecutionStatus.StepDefinitionPending:
                 ExtendedApi.SkipStep(
-                    s => s.statusDetails.message = STEP_PENDING_MESSAGE
+                    s => s.statusDetails = new() { message = STEP_PENDING_MESSAGE }
                 );
                 break;
             case ScenarioExecutionStatus.Skipped:
@@ -198,14 +198,13 @@ static class AllureReqnrollStateFacade
                 break;
             case ScenarioExecutionStatus.UndefinedStep:
                 ExtendedApi.BreakStep(
-                    s => s.statusDetails.message = STEP_UNKNOWN_MESSAGE
+                    s => s.statusDetails = new() { message = STEP_UNKNOWN_MESSAGE }
                 );
                 break;
             case ScenarioExecutionStatus.BindingError:
-                ExtendedApi.BreakStep(s =>
-                {
-                    s.statusDetails.message = error!.Message;
-                });
+                ExtendedApi.BreakStep(
+                    s => s.statusDetails = new() { message = error!.Message }
+                );
                 break;
             case ScenarioExecutionStatus.TestError:
                 ExtendedApi.ResolveStep(error!);

--- a/src/Allure.SpecFlow/PluginHelper.cs
+++ b/src/Allure.SpecFlow/PluginHelper.cs
@@ -350,10 +350,10 @@ namespace Allure.SpecFlowPlugin
                 _ => status
             };
 
-        static StatusDetails ResolveTestCaseDetails(
+        static StatusDetails? ResolveTestCaseDetails(
             ScenarioContext scenarioContext,
             Status status,
-            StatusDetails statusDetails
+            StatusDetails? statusDetails
         ) =>
             status switch
             {

--- a/tests/Allure.Net.Commons.Tests/UserAPITests/AllureFacadeTests/StepTests/ExplicitFixtureAndStepTests.cs
+++ b/tests/Allure.Net.Commons.Tests/UserAPITests/AllureFacadeTests/StepTests/ExplicitFixtureAndStepTests.cs
@@ -148,14 +148,14 @@ internal class ExplicitFixtureAndStepTests : AllureApiTestFixture
     void AssertFixtureStatus(Status status, string message, string trace)
     {
         Assert.That(this.fixture!.status, Is.EqualTo(status));
-        Assert.That(this.fixture.statusDetails.message, Is.EqualTo(message));
-        Assert.That(this.fixture.statusDetails.trace, Contains.Substring(trace));
+        Assert.That(this.fixture.statusDetails?.message, Is.EqualTo(message));
+        Assert.That(this.fixture.statusDetails?.trace, Contains.Substring(trace));
     }
 
     static void AssertStepStatus(StepResult step, Status status, string message, string trace)
     {
         Assert.That(step.status, Is.EqualTo(status));
-        Assert.That(step.statusDetails.message, Is.EqualTo(message));
-        Assert.That(step.statusDetails.trace, Contains.Substring(trace));
+        Assert.That(step.statusDetails?.message, Is.EqualTo(message));
+        Assert.That(step.statusDetails?.trace, Contains.Substring(trace));
     }
 }


### PR DESCRIPTION
### Context

The PR sets the default value of `ExecutableItem.statusDetails` to null, which precludes it from test result files. This has two effects:

  - the size of test results is slightly reduced
  - the fallback logic becomes simpler (`??=` instead of value set tracking)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
