### PR TITLE
Allow integrations to overwrite `stop`

### DIFF
--- a/src/Allure.Net.Commons/AllureLifecycle.cs
+++ b/src/Allure.Net.Commons/AllureLifecycle.cs
@@ -401,20 +401,27 @@ public class AllureLifecycle
     /// <summary>
     /// Stops the current fixture and deactivates the fixture context.
     /// </summary>
-    /// <param name="beforeStop">
-    /// A function applied to the fixture result before it is stopped.
+    /// <param name="onStop">
+    /// A function applied to the fixture result right after it is stopped.
     /// </param>
     /// <remarks>
     /// This method modifies the Allure context.<br></br>
-    /// Required the fixture context to be active.
+    /// Requires the fixture context to be active.
     /// </remarks>
     /// <exception cref="InvalidOperationException"/>
     public virtual AllureLifecycle StopFixture(
-        Action<FixtureResult> beforeStop
+        Action<FixtureResult> onStop
     )
     {
-        this.UpdateFixture(beforeStop);
-        return this.StopFixture();
+        var fixture = this.Context.CurrentFixture;
+        this.StopFixture();
+
+        lock (this.modelMonitor)
+        {
+            onStop(fixture);
+        }
+
+        return this;
     }
 
     /// <summary>
@@ -422,7 +429,7 @@ public class AllureLifecycle
     /// </summary>
     /// <remarks>
     /// This method modifies the Allure context.<br></br>
-    /// Required the fixture context to be active.
+    /// Requires the fixture context to be active.
     /// </remarks>
     /// <exception cref="InvalidOperationException"/>
     public virtual AllureLifecycle StopFixture()
@@ -513,14 +520,14 @@ public class AllureLifecycle
     /// <remarks>
     /// Requires the test context to be active.
     /// </remarks>
-    /// <param name="beforeStop">
-    /// A function applied to the test result before it is stopped.
+    /// <param name="onStop">
+    /// A function applied to the test result right after it is stopped.
     /// </param>
     /// <exception cref="InvalidOperationException"/>
     public virtual AllureLifecycle StopTestCase(
-        Action<TestResult> beforeStop
+        Action<TestResult> onStop
     ) => this.UpdateTestCase(
-        Chain(beforeStop, stopTestCase)
+        Chain(stopTestCase, onStop)
     );
 
     /// <summary>
@@ -611,14 +618,21 @@ public class AllureLifecycle
     /// This method modifies the Allure context.<br></br>
     /// Requires the step context to be active.
     /// </remarks>
-    /// <param name="beforeStop">
-    /// A function that is applied to the step result before it is stopped.
+    /// <param name="onStop">
+    /// A function that is applied to the step result right after it is stopped.
     /// </param>
     /// <exception cref="InvalidOperationException"/>
-    public virtual AllureLifecycle StopStep(Action<StepResult> beforeStop)
+    public virtual AllureLifecycle StopStep(Action<StepResult> onStop)
     {
-        this.UpdateStep(beforeStop);
-        return this.StopStep();
+        var stepResult = this.Context.CurrentStep;
+        this.StopStep();
+
+        lock (this.modelMonitor)
+        {
+            onStop(stepResult);
+        }
+
+        return this;
     }
 
     /// <summary>
@@ -724,29 +738,32 @@ public class AllureLifecycle
     }
 
     static readonly Action<TestResultContainer> stopContainer =
-        c => c.stop = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        static c => c.stop = DateTimeOffset.Now.ToUnixTimeMilliseconds();
 
     static readonly Action<ExecutableItem> startAllureItem =
-        item =>
+        static item =>
         {
             item.stage = Stage.running;
             item.start = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         };
 
     static readonly Action<ExecutableItem> stopAllureItem =
-        item =>
+        static item =>
         {
             item.stage = Stage.finished;
-            item.stop = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            if (item.stop == default)
+            {
+                item.stop = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+            }
         };
 
     static readonly Action<TestResult> stopTestCase = Chain(
         stopAllureItem,
-        (TestResult tr) => tr.historyId ??= IdFunctions.CreateHistoryId(
+        static (TestResult tr) => tr.historyId ??= IdFunctions.CreateHistoryId(
             tr.fullName,
             tr.parameters
         ),
-        (TestResult tr) => tr.testCaseId ??= IdFunctions.CreateTestCaseId(
+        static tr => tr.testCaseId ??= IdFunctions.CreateTestCaseId(
             tr.fullName
         )
     );

--- a/tests/Allure.Net.Commons.Tests/AllureLifeCycleTest.cs
+++ b/tests/Allure.Net.Commons.Tests/AllureLifeCycleTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Allure.Net.Commons.Sdk.Writers;
 using NUnit.Framework;
@@ -312,6 +313,96 @@ namespace Allure.Net.Commons.Tests
             lifecycle.WriteTestContainer();
 
             Assert.That(writer.TestContainers, Has.One.Items);
+        }
+
+        [Test]
+        public void StopFixtureCallsCallbackAfterStatusSet()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(new(), writer)
+                .StartTestContainer(new() { uuid = "c1" })
+                .StartBeforeFixture(new());
+
+            lifecycle.StopFixture((f) => f.stop = 100)
+                .WriteTestContainer();
+
+            var fixture = writer.TestContainers.Single().befores.Single();
+            Assert.That(fixture.stop, Is.EqualTo(100));
+        }
+
+        [Test]
+        public void StopTestCaseCallsCallbackAfterStatusSet()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(new(), writer)
+                .StartTestCase(new(){ uuid = "t1", fullName = "fn" });
+
+            lifecycle.StopTestCase((t) => t.stop = 100)
+                .WriteTestCase();
+
+            var testResult = writer.TestResults.Single();
+            Assert.That(testResult.stop, Is.EqualTo(100));
+        }
+
+        [Test]
+        public void StopStepCallsCallbackAfterStatusSet()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(new(), writer)
+                .StartTestCase(new(){ uuid = "t1", fullName = "fn" })
+                .StartStep(new());
+
+            lifecycle.StopStep((s) => s.stop = 100)
+                .StopTestCase()
+                .WriteTestCase();
+
+            var step = writer.TestResults.Single().steps.Single();
+            Assert.That(step.stop, Is.EqualTo(100));
+        }
+
+        [Test]
+        public void StopFixtureDoesNotUpdateStopIfAlreadySet()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(new(), writer)
+                .StartTestContainer(new() { uuid = "c1" })
+                .StartBeforeFixture(new() { stop = 100 });
+
+            lifecycle.StopFixture()
+                .WriteTestContainer();
+
+            var fixture = writer.TestContainers.Single().befores.Single();
+            Assert.That(fixture.stop, Is.EqualTo(100));
+        }
+
+        [Test]
+        public void StopTestCaseDoesNotUpdateStopIfAlreadySet()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(new(), writer)
+                .StartTestCase(new(){ uuid = "t1", fullName = "fn", stop = 100 });
+
+            lifecycle.StopTestCase()
+                .WriteTestCase();
+
+            var testResult = writer.TestResults.Single();
+            Assert.That(testResult.stop, Is.EqualTo(100));
+        }
+
+        [Test]
+        public void StopStepDoesNotUpdateStopIfAlreadySet()
+        {
+            var writer = new InMemoryResultsWriter();
+            var lifecycle = new AllureLifecycle(new(), writer)
+                .StartTestCase(new(){ uuid = "t1", fullName = "fn" })
+                .StartStep(new() { stop = 100 });
+
+            lifecycle.StopStep()
+                .StopTestCase()
+                .WriteTestCase();
+
+            var step = writer.TestResults.Single().steps.Single();
+            Assert.That(step.stop, Is.EqualTo(100));
         }
     }
 }


### PR DESCRIPTION
### Context

The PR changes `AllureLifecycle.StopTestCase`, `AllureLifecycle.StopFixture`, and `AllureLifecycle.StopStep` to call their callbacks after they update `stage` and `stop`, not before. This allows integrations to set the timings based on their own sources of truth rather than relying on `DateTimeOffset.Now`, which may give incorrect results in some message-based architectures.

Additionally, these functions now check whether the `stop` timestamp has already been set before setting it to `DateTimeOffset.Now`, so integrations that receive the timings separately from test stop events don't have to store them.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
