### PR TITLE
Reference sample files directly from sample projects

### DIFF
--- a/build/Allure.Build.Tasks/DataTypes/AllureSample.cs
+++ b/build/Allure.Build.Tasks/DataTypes/AllureSample.cs
@@ -8,5 +8,7 @@ public record class AllureSample(
     string RegistryNamespace,
     string ProjectName,
     ImmutableArray<(string key, string value)> MsbuildProperties,
+    string ItemType,
+    ImmutableArray<(string key, string value)> ItemMetadata,
     bool WellDefined
 );

--- a/build/Allure.Build.Tasks/FillSampleMetadata.cs
+++ b/build/Allure.Build.Tasks/FillSampleMetadata.cs
@@ -60,7 +60,7 @@ public class FillSampleMetadata : Task
 
     void EnsureSampleMetadata(ITaskItem2 sample)
     {
-        var fragments = this.GetSampleFqNameFragmants(sample.EvaluatedIncludeEscaped);
+        var fragments = this.GetSampleFqNameFragments(sample.ItemSpec);
 
         if (fragments.Length == 0)
         {
@@ -89,7 +89,7 @@ public class FillSampleMetadata : Task
 
         if (IsMetadataMissing(sample, "ProjectFilePath"))
         {
-            var projectName = sample.GetMetadataValueEscaped("ProjectName");
+            var projectName = sample.GetMetadata("ProjectName");
             var path = Path.Combine(
                 this.SampleSolutionDirectory,
                 projectName,
@@ -104,7 +104,7 @@ public class FillSampleMetadata : Task
                 this.RootDirectory,
                 Path.Combine(
                     this.SampleSolutionDirectory,
-                    sample.GetMetadataValueEscaped("ProjectName")
+                    sample.GetMetadata("ProjectName")
                 )
             );
             sample.SetMetadataValueLiteral("ProjectRelativePath", path);
@@ -119,7 +119,7 @@ public class FillSampleMetadata : Task
         {
             var path = Path.Combine(
                 this.BinDirectory,
-                sample.GetMetadataValueEscaped("ProjectName")
+                sample.GetMetadata("ProjectName")
             );
             sample.SetMetadataValueLiteral("ProjectBinPath", path);
         }
@@ -128,14 +128,14 @@ public class FillSampleMetadata : Task
         {
             var path = Path.Combine(
                 this.ObjDirectory,
-                sample.GetMetadataValueEscaped("ProjectName")
+                sample.GetMetadata("ProjectName")
             );
             sample.SetMetadataValueLiteral("ProjectObjPath", path);
         }
     }
 
-    static bool IsMetadataMissing(ITaskItem2 item, string key) =>
-        string.IsNullOrEmpty(item.GetMetadataValueEscaped(key));
+    static bool IsMetadataMissing(ITaskItem item, string key) =>
+        string.IsNullOrEmpty(item.GetMetadata(key));
 
     void SetResultsDirectory(ITaskItem2 item)
     {
@@ -143,14 +143,14 @@ public class FillSampleMetadata : Task
         var targetFramework = this.TargetFramework.ToLowerInvariant();
         var defaultResultsDirectory = Path.Join(
             this.BinDirectory,
-            item.GetMetadataValueEscaped("ProjectName"),
+            item.GetMetadata("ProjectName"),
             $"{configuration}_{targetFramework}",
             "allure-results"
         );
         item.SetMetadataValueLiteral("ResultsDirectory", defaultResultsDirectory);
     }
 
-    ImmutableArray<string> GetSampleFqNameFragmants(string samplePath)
+    ImmutableArray<string> GetSampleFqNameFragments(string samplePath)
     {
         var fragments = this.GetPathFragments(samplePath).Reverse().ToList();
 

--- a/build/Allure.Build.Tasks/Functions/Collections.cs
+++ b/build/Allure.Build.Tasks/Functions/Collections.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Allure.Build.Tasks.Functions;
+
+public static class Collections
+{
+    public static IEnumerable<R> MapNotEmpty<T, R>(IEnumerable<T> sequence, Func<IEnumerable<T>, R> map) =>
+        sequence.ToImmutableArray() is { IsEmpty: false } array
+            ? [map(array)]
+            : [];
+
+    public static IEnumerable<R> MapNotEmpty<R>(string value, Func<string, R> map) =>
+        string.IsNullOrEmpty(value)
+            ? []
+            : [map(value)];
+}

--- a/build/Allure.Build.Tasks/Functions/Files.cs
+++ b/build/Allure.Build.Tasks/Functions/Files.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Allure.Build.Tasks.DataTypes;
 
 namespace Allure.Build.Tasks.Functions;
 
@@ -26,11 +27,13 @@ public static class Files
         IEnumerable<string> projects
     ) =>
         GeneratedFileSource.FromXmlDocument(
-            document: XmlDefinitions.Solution(projects),
+            document: XmlDefinitions.Solution(
+                sampleSolutionRelativeProjectPath: projects
+                    .Select((p) => Path.GetRelativePath(solutionFilePath, p))
+            ),
             destinationPath: solutionFilePath,
             omitDeclaration: true
         );
-
 
     public static GeneratedFileSource DirectorySolutionTargets(
         string solutionDir
@@ -83,10 +86,20 @@ public static class Files
         string projectDir,
         string projectName,
         IEnumerable<(string key, string value)> properties,
-        IEnumerable<string> compile
+        IEnumerable<AllureSample> files
     ) =>
         GeneratedFileSource.FromXmlDocument(
-            document: XmlDefinitions.Project(properties, compile),
+            document: XmlDefinitions.Project(
+                projectProperties: properties,
+                groupedProjectItems: files.GroupBy(
+                    static (file) => file.ItemType,
+                    (file) => (
+                        path: Path.GetRelativePath(projectDir, file.Path),
+                        metadata: file.ItemMetadata
+                    ),
+                    static (itemType, items) => (itemType, items)
+                )
+            ),
             destinationPath: Path.Combine(projectDir, $"{projectName}.csproj"),
             omitDeclaration: true
         );

--- a/build/Allure.Build.Tasks/Functions/Files.cs
+++ b/build/Allure.Build.Tasks/Functions/Files.cs
@@ -80,13 +80,14 @@ public static class Files
         );
 
     public static GeneratedFileSource Project(
-        string solutionDir,
+        string projectDir,
         string projectName,
-        IEnumerable<(string key, string value)> properties
+        IEnumerable<(string key, string value)> properties,
+        IEnumerable<string> compile
     ) =>
         GeneratedFileSource.FromXmlDocument(
-            document: XmlDefinitions.Project(properties),
-            destinationPath: Path.Combine(solutionDir, projectName, $"{projectName}.csproj"),
+            document: XmlDefinitions.Project(properties, compile),
+            destinationPath: Path.Combine(projectDir, $"{projectName}.csproj"),
             omitDeclaration: true
         );
 

--- a/build/Allure.Build.Tasks/Functions/Files.cs
+++ b/build/Allure.Build.Tasks/Functions/Files.cs
@@ -24,13 +24,10 @@ public static class Files
 
     public static GeneratedFileSource Solution(
         string solutionFilePath,
-        IEnumerable<string> projects
+        IEnumerable<string> sampleSolutionRelativeProjectPath
     ) =>
         GeneratedFileSource.FromXmlDocument(
-            document: XmlDefinitions.Solution(
-                sampleSolutionRelativeProjectPath: projects
-                    .Select((p) => Path.GetRelativePath(solutionFilePath, p))
-            ),
+            document: XmlDefinitions.Solution(sampleSolutionRelativeProjectPath),
             destinationPath: solutionFilePath,
             omitDeclaration: true
         );

--- a/build/Allure.Build.Tasks/Functions/Imports.cs
+++ b/build/Allure.Build.Tasks/Functions/Imports.cs
@@ -15,14 +15,14 @@ public static partial class Imports
         TaskLoggingHelper log,
         string sampleSolutionDir,
         string testProjectDirectory,
-        IEnumerable<ITaskItem2> projectReferences
+        IEnumerable<ITaskItem> projectReferences
     ) =>
         projectReferences
             .Select((r) => CollectDependencyImportFiles(
                 buildEngine,
                 log,
                 sampleSolutionDir,
-                Path.GetFullPath(r.EvaluatedIncludeEscaped, testProjectDirectory)
+                Path.GetFullPath(r.ItemSpec, testProjectDirectory)
             ))
             .Aggregate(new MsBuildImportFiles([], []), (f, s) => f with
             {
@@ -74,7 +74,7 @@ public static partial class Imports
                                         select Path.Combine(dir, $"{projectName2}.targets"))
                                             .ToImmutableArray()
             from projectTargetOutput in outputs[projectIndex].Values
-            from ITaskItem2 packageFile in projectTargetOutput
+            from packageFile in projectTargetOutput
             let packagePaths = Files.GetOsMatchingPath(packageFile.GetMetadata("PackagePath"))
                     .Split(';')
                     .Select(static (p) => p.TrimStart(Path.DirectorySeparatorChar))

--- a/build/Allure.Build.Tasks/Functions/Logging.cs
+++ b/build/Allure.Build.Tasks/Functions/Logging.cs
@@ -133,7 +133,7 @@ public static class Logging
 
     public static void LogInvalidSampleNameWarning(
         TaskLoggingHelper log,
-        ITaskItem sample,
+        ITaskItem2 sample,
         string sampleName,
         string projectDirectory
     )
@@ -151,7 +151,9 @@ public static class Logging
                   """,
             sample.ItemSpec,
             sampleName,
-            Path.GetRelativePath(projectDirectory, sample.ItemSpec)
+            // Keep escapint to display a value that is ready for copy and paste
+            // to the test project file.
+            Path.GetRelativePath(projectDirectory, sample.EvaluatedIncludeEscaped)
         );
 
     public static void LogInvalidRegistryNamespaceWarning(

--- a/build/Allure.Build.Tasks/Functions/Logging.cs
+++ b/build/Allure.Build.Tasks/Functions/Logging.cs
@@ -100,20 +100,6 @@ public static class Logging
     public static void LogStaleDeletion(TaskLoggingHelper log, string path)
         => log.LogMessage($"Deleted a stale file '{path}'.");
 
-    public static void LogFileOutsideProjectWarning(
-        TaskLoggingHelper log,
-        string sampleProjectDir,
-        string path,
-        string relativeSampleFilePath
-    )
-        => log.LogWarning(
-            "Ignoring '{0}': the file's calculated destination '{1}' is outside of the "
-                + "sample project directory '{2}'",
-            path,
-            relativeSampleFilePath,
-            sampleProjectDir
-        );
-
     public static void LogMissingCommonPrefixWarning(
         TaskLoggingHelper log,
         IEnumerable<AllureSample> projectSamples,

--- a/build/Allure.Build.Tasks/Functions/Logging.cs
+++ b/build/Allure.Build.Tasks/Functions/Logging.cs
@@ -12,34 +12,34 @@ public static class Logging
 {
     public static void LogResolveRegistryEntryNoMetadata(
         TaskLoggingHelper log,
-        ITaskItem2 item,
+        ITaskItem item,
         string metadataKey
     ) =>
         log.LogError(
             "Invalid sample file '{0}': no {1} defined.",
-            item.EvaluatedIncludeEscaped,
+            item.ItemSpec,
             metadataKey
         );
 
     public static void LogResolveRegistryEntryInvalidNamespace(
         TaskLoggingHelper log,
-        ITaskItem2 item,
+        ITaskItem item,
         string registryNamespace
     ) =>
         log.LogError(
             "Invalid sample file '{0}': invalid RegistryNamespace '{1}'. The value must be a valid namespace.",
-            item.EvaluatedIncludeEscaped,
+            item.ItemSpec,
             registryNamespace
         );
 
     public static void LogResolveRegistryEntryInvalidSampleName(
         TaskLoggingHelper log,
-        ITaskItem2 item,
+        ITaskItem item,
         string sampleName
     ) =>
         log.LogError(
             "Invalid sample file '{0}': invalid SampleName '{1}'. The value must be a valid C# identifier.",
-            item.EvaluatedIncludeEscaped,
+            item.ItemSpec,
             sampleName
         );
 
@@ -114,26 +114,26 @@ public static class Logging
             )
         );
 
-    public static void LogNoPath(TaskLoggingHelper log, ITaskItem2 item) =>
-        log.LogWarning("Ignoring '{0}': bad path.", item.EvaluatedIncludeEscaped);
+    public static void LogNoPath(TaskLoggingHelper log, ITaskItem item) =>
+        log.LogWarning("Ignoring '{0}': bad path.", item.ItemSpec);
 
-    public static void LogFileNotExist(TaskLoggingHelper log, ITaskItem2 item) =>
-        log.LogWarning("Ignoring '{0}': the file does not exist.", item.EvaluatedIncludeEscaped);
+    public static void LogFileNotExist(TaskLoggingHelper log, ITaskItem item) =>
+        log.LogWarning("Ignoring '{0}': the file does not exist.", item.ItemSpec);
 
     public static void LogNoMetadata(
         TaskLoggingHelper log,
-        ITaskItem2 item,
+        ITaskItem item,
         string metadataKey
     ) =>
         log.LogWarning(
             "Ignoring '{0}': no {1} defined on the item.",
-            item.EvaluatedIncludeEscaped,
+            item.ItemSpec,
             metadataKey
         );
 
     public static void LogInvalidSampleNameWarning(
         TaskLoggingHelper log,
-        ITaskItem2 sample,
+        ITaskItem sample,
         string sampleName,
         string projectDirectory
     )
@@ -149,14 +149,14 @@ public static class Logging
                     </ItemGroup>
 
                   """,
-            sample.EvaluatedIncludeEscaped,
+            sample.ItemSpec,
             sampleName,
-            Path.GetRelativePath(projectDirectory, sample.EvaluatedIncludeEscaped)
+            Path.GetRelativePath(projectDirectory, sample.ItemSpec)
         );
 
     public static void LogInvalidRegistryNamespaceWarning(
         TaskLoggingHelper log,
-        ITaskItem2 sample,
+        ITaskItem sample,
         string registryNamespace,
         string projectDirectory,
         string rootNamespace
@@ -173,9 +173,9 @@ public static class Logging
                     </ItemGroup>
 
                   """,
-            sample.EvaluatedIncludeEscaped,
+            sample.ItemSpec,
             registryNamespace,
-            Path.GetRelativePath(projectDirectory, sample.EvaluatedIncludeEscaped),
+            Path.GetRelativePath(projectDirectory, sample.ItemSpec),
             rootNamespace
         );
 

--- a/build/Allure.Build.Tasks/Functions/MsBuild.cs
+++ b/build/Allure.Build.Tasks/Functions/MsBuild.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -17,7 +17,7 @@ public static class Projects
         string sampleSolutionDir,
         string testProjectDirectory,
         string testProjectRootNamespace,
-        IEnumerable<ITaskItem> sampleSources
+        IEnumerable<ITaskItem2> sampleSources
     ) =>
         [
             ..sampleSources
@@ -38,8 +38,7 @@ public static class Projects
         TaskLoggingHelper log,
         string testProjectDirectory,
         string testProjectRootNamespace,
-        ImmutableDictionary<string, string> itemTypeMap,
-        ITaskItem sample
+        ITaskItem2 sample
     )
     {
         var path = GetSamplePath(log, testProjectDirectory, sample);
@@ -53,7 +52,8 @@ public static class Projects
         var projectName = GetSampleMetadata(log, sample, "ProjectName");
         var properties = GetSampleSpecificProperties(sample);
 
-        var rawItemType = sample.GetMetadata("ItemType");
+        // Keep escaping as it becomes an XML element name
+        var rawItemType = sample.GetMetadataValueEscaped("ItemType");
         var itemTypeDefined = rawItemType is { Length: > 0 };
         var resolvedItemType = itemTypeDefined ? rawItemType : "None";
 
@@ -94,7 +94,8 @@ public static class Projects
 
     static string[] GetSplittedItemMetadata(ITaskItem2 sample) =>
         sample
-            .GetMetadata("ItemMetadata")
+            // Keep escaping to allow using special characters in item attribute names and values
+            .GetMetadataValueEscaped("ItemMetadata")
             .Split(';', StringSplitOptions.RemoveEmptyEntries);
 
     static GeneratedFileSource GenerateProject(
@@ -146,7 +147,7 @@ public static class Projects
     static string GetSampleName(
         TaskLoggingHelper log,
         string testProjectDirectory,
-        ITaskItem sample
+        ITaskItem2 sample
     )
     {
         var sampleName = GetSampleMetadata(log, sample, "SampleName");
@@ -198,11 +199,12 @@ public static class Projects
     }
 
     static ImmutableArray<(string key, string value)> GetSampleSpecificProperties(
-        ITaskItem sample
+        ITaskItem2 sample
     )
         => [
             .. sample
-                .GetMetadata("Properties")
+                // Keep escaping as we're writing these values in the project file directly.
+                .GetMetadataValueEscaped("Properties")
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
                 .Select(static (p) => p.Split('=', StringSplitOptions.RemoveEmptyEntries))
                 .Where(static (p) => p.Length == 2)

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -192,10 +192,30 @@ public static class Projects
         string greatestCommonPrefix
     )
     {
+        var sampleProjectDir = Path.Combine(sampleSolutionDir, sampleProjectName);
+
+        var sampleSources = PrepareSampleSources(
+            log: log,
+            samples: samples,
+            greatestCommonPrefix: greatestCommonPrefix,
+            sampleProjectDir: sampleProjectDir
+        )
+            .GroupBy(static (s) => s.Destination.Extension)
+            .ToImmutableDictionary(
+                static (g) => g.Key,
+                static (g) => g.ToImmutableArray(),
+                StringComparer.OrdinalIgnoreCase
+            );
+
+        var compile = sampleSources
+                .GetValueOrDefault(".cs", [])
+                .Select((cs) => Path.GetRelativePath(sampleProjectDir, cs.Source.FullName));
+
         var csproj = Files.Project(
-            sampleSolutionDir,
-            sampleProjectName,
-            properties: GetSampleProjectProperties(samples)
+            projectDir: sampleProjectDir,
+            projectName: sampleProjectName,
+            properties: GetSampleProjectProperties(samples),
+            compile: compile
         );
 
         var csprojRelativePath = Path.GetRelativePath(
@@ -203,14 +223,11 @@ public static class Projects
             csproj.Destination.FullName
         );
 
-        var sampleSources = PrepareSampleSources(
-            log,
-            samples,
-            greatestCommonPrefix,
-            csproj.Destination.Directory.FullName
-        );
+        var restProjectSampleSources = sampleSources
+            .Where(static (kv) => !StringComparer.OrdinalIgnoreCase.Equals(kv.Key, ".cs"))
+            .SelectMany(static (kv) => kv.Value);
 
-        return (csprojRelativePath, [csproj, ..sampleSources]);
+        return (csprojRelativePath, [csproj, ..restProjectSampleSources]);
     }
 
     static IEnumerable<MappedFileSource> PrepareSampleSources(

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -17,7 +17,6 @@ public static class Projects
         string sampleSolutionDir,
         string testProjectDirectory,
         string testProjectRootNamespace,
-        ImmutableDictionary<string, string> itemTypeMap,
         IEnumerable<ITaskItem> sampleSources
     ) =>
         [
@@ -26,7 +25,6 @@ public static class Projects
                     log,
                     testProjectDirectory,
                     testProjectRootNamespace,
-                    itemTypeMap,
                     sampleItem
                 ))
                 .Where(static (sample) => sample.WellDefined)
@@ -54,7 +52,13 @@ public static class Projects
         );
         var projectName = GetSampleMetadata(log, sample, "ProjectName");
         var properties = GetSampleSpecificProperties(sample);
-        var itemType = itemTypeMap.GetValueOrDefault(Path.GetExtension(path), "None");
+
+        var rawItemType = sample.GetMetadata("ItemType");
+        var itemTypeDefined = rawItemType is { Length: > 0 };
+        var resolvedItemType = itemTypeDefined ? rawItemType : "None";
+
+        ImmutableArray<(string key, string value)> itemMetadata =
+            ExtractSampleItemMetadata(sample);
 
         var wellDefined
             = path.Length > 0
@@ -68,20 +72,30 @@ public static class Projects
             RegistryNamespace: registryNamespace,
             ProjectName: projectName,
             MsbuildProperties: properties,
-            ItemType: itemType,
+            ItemType: resolvedItemType,
             ItemMetadata: [
-                ..itemType is not "None"
-                    || sample.MetadataNames.OfType<string>().Contains("Sample_CopyToOutputDirectory")
-                        ? (IEnumerable<(string, string)>)[]
-                        : [("CopyToOutputDirectory", "PreserveNewest")],
-                ..sample.MetadataNames
-                    .OfType<string>()
-                    .Where(static (n) => n.StartsWith("Sample_"))
-                    .Select((n) => (key: n, value: sample.GetMetadata(n)))
+                ..!itemTypeDefined && !itemMetadata.Any(static (kv) => kv.key == "CopyToOutputDirectory")
+                    ? [("CopyToOutputDirectory", "PreserveNewest")]
+                    : (IEnumerable<(string, string)>)[],
+                ..itemMetadata,
             ],
             WellDefined: wellDefined
         );
     }
+
+    static ImmutableArray<(string key, string value)> ExtractSampleItemMetadata(ITaskItem2 sample) => [
+        ..
+        from singleMetadata in GetSplittedItemMetadata(sample)
+        let kvArray = singleMetadata.Split('=', 2)
+        where kvArray is [{ Length: >0 }, ..]
+        group kvArray is [_, var value] ? value : "" by kvArray[0] into valueGroup
+        select (valueGroup.Key, string.Join(";", valueGroup)),
+    ];
+
+    static string[] GetSplittedItemMetadata(ITaskItem2 sample) =>
+        sample
+            .GetMetadata("ItemMetadata")
+            .Split(';', StringSplitOptions.RemoveEmptyEntries);
 
     static GeneratedFileSource GenerateProject(
         TaskLoggingHelper log,

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
-using Allure.Build.Tasks.Sources;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.CodeAnalysis.CSharp;
@@ -13,42 +12,39 @@ namespace Allure.Build.Tasks.Functions;
 
 public static class Projects
 {
-    public static (ImmutableArray<string> paths, ImmutableArray<FileSource> sources) GenerateProjects(
+    public static ImmutableArray<GeneratedFileSource> GenerateProjects(
         TaskLoggingHelper log,
         string sampleSolutionDir,
         string testProjectDirectory,
         string testProjectRootNamespace,
+        ImmutableDictionary<string, string> itemTypeMap,
         IEnumerable<ITaskItem2> sampleSources
-    )
-    {
-        var x = sampleSources
-            .Select((sampleItem) => ToAllureSample(
-                log,
-                testProjectDirectory,
-                testProjectRootNamespace,
-                sampleItem
-            ))
-            .Where(static (sample) => sample.WellDefined)
-            .GroupBy(
-                static (sample) => sample.ProjectName)
-            .Select((group) => GenerateProject(log, sampleSolutionDir, group.Key, [..group]))
-            .Where(static (pair) => pair.path is not null)
-            .ToImmutableArray();
-
-        return (
-            [..x.Select(static (p) => p.path)],
-            [..x.SelectMany(static (p) => p.files)]
-        );
-    }
+    ) =>
+        [
+            ..sampleSources
+                .Select((sampleItem) => ToAllureSample(
+                    log,
+                    testProjectDirectory,
+                    testProjectRootNamespace,
+                    itemTypeMap,
+                    sampleItem
+                ))
+                .Where(static (sample) => sample.WellDefined)
+                .GroupBy(
+                    static (sample) => sample.ProjectName)
+                .Select((group) => GenerateProject(log, sampleSolutionDir, group.Key, [..group]))
+                .Where(static (csproj) => csproj is not null)
+        ];
 
     static AllureSample ToAllureSample(
         TaskLoggingHelper log,
         string testProjectDirectory,
         string testProjectRootNamespace,
+        ImmutableDictionary<string, string> itemTypeMap,
         ITaskItem2 sample
     )
     {
-        var path = GetSamplePath(log, sample);
+        var path = GetSamplePath(log, testProjectDirectory, sample);
         var sampleName = GetSampleName(log, testProjectDirectory, sample);
         var registryNamespace = GetRegistryNamespace(
             log,
@@ -58,17 +54,36 @@ public static class Projects
         );
         var projectName = GetSampleMetadata(log, sample, "ProjectName");
         var properties = GetSampleSpecificProperties(sample);
+        var itemType = itemTypeMap.GetValueOrDefault(Path.GetExtension(path), "None");
 
-        var wellDefines
+        var wellDefined
             = path.Length > 0
                 && sampleName.Length > 0
                 && registryNamespace.Length > 0
                 && projectName.Length > 0;
 
-        return new (path, sampleName, registryNamespace, projectName, properties, wellDefines);
+        return new(
+            Path: path,
+            SampleName: sampleName,
+            RegistryNamespace: registryNamespace,
+            ProjectName: projectName,
+            MsbuildProperties: properties,
+            ItemType: itemType,
+            ItemMetadata: [
+                ..itemType is not "None"
+                    || sample.MetadataNames.OfType<string>().Contains("Sample_CopyToOutputDirectory")
+                        ? (IEnumerable<(string, string)>)[]
+                        : [("CopyToOutputDirectory", "PreserveNewest")],
+                ..sample.MetadataNames
+                    .OfType<string>()
+                    .Where(static (n) => n.StartsWith("Sample_"))
+                    .Select((n) => (key: n, value: sample.GetMetadata(n)))
+            ],
+            WellDefined: wellDefined
+        );
     }
 
-    static (string path, ImmutableArray<FileSource> files) GenerateProject(
+    static GeneratedFileSource GenerateProject(
         TaskLoggingHelper log,
         string sampleSolutionDir,
         string sampleProjectName,
@@ -79,30 +94,33 @@ public static class Projects
         if (greatestCommonPrefix is "")
         {
             Logging.LogMissingCommonPrefixWarning(log, samples, sampleProjectName);
-            return (null, []);
+            return null;
         }
 
         Logging.LogGreatestCommonPrefixMessage(log, sampleProjectName, greatestCommonPrefix);
 
         return CreateProjectFileSources(
-            log,
             sampleSolutionDir,
             sampleProjectName,
-            samples,
-            greatestCommonPrefix
+            samples
         );
     }
 
-    static string GetSamplePath(TaskLoggingHelper log, ITaskItem2 sample)
+    static string GetSamplePath(
+        TaskLoggingHelper log,
+        string basePath,
+        ITaskItem2 sample
+    )
     {
-        var path = sample.EvaluatedIncludeEscaped;
+        var path = sample.ItemSpec;
         if (string.IsNullOrEmpty(path))
         {
             Logging.LogNoPath(log, sample);
             return "";
         }
 
-        if (!Path.Exists(path))
+        var fullPath = Path.GetFullPath(path, basePath);
+        if (!Path.Exists(fullPath))
         {
             Logging.LogFileNotExist(log, sample);
             return "";
@@ -184,89 +202,17 @@ public static class Projects
     static string GetGreatestCommonPrefix(IEnumerable<AllureSample> samples) =>
         Files.GetGreatestCommonPrefix(samples.Select(static sample => sample.Path));
 
-    static (string, ImmutableArray<FileSource>) CreateProjectFileSources(
-        TaskLoggingHelper log,
+    static GeneratedFileSource CreateProjectFileSources(
         string sampleSolutionDir,
         string sampleProjectName,
-        ImmutableArray<AllureSample> samples,
-        string greatestCommonPrefix
-    )
-    {
-        var sampleProjectDir = Path.Combine(sampleSolutionDir, sampleProjectName);
-
-        var sampleSources = PrepareSampleSources(
-            log: log,
-            samples: samples,
-            greatestCommonPrefix: greatestCommonPrefix,
-            sampleProjectDir: sampleProjectDir
-        )
-            .GroupBy(static (s) => s.Destination.Extension)
-            .ToImmutableDictionary(
-                static (g) => g.Key,
-                static (g) => g.ToImmutableArray(),
-                StringComparer.OrdinalIgnoreCase
-            );
-
-        var compile = sampleSources
-                .GetValueOrDefault(".cs", [])
-                .Select((cs) => Path.GetRelativePath(sampleProjectDir, cs.Source.FullName));
-
-        var csproj = Files.Project(
-            projectDir: sampleProjectDir,
+        ImmutableArray<AllureSample> samples
+    ) =>
+        Files.Project(
+            projectDir: Path.Combine(sampleSolutionDir, sampleProjectName),
             projectName: sampleProjectName,
             properties: GetSampleProjectProperties(samples),
-            compile: compile
+            files: samples
         );
-
-        var csprojRelativePath = Path.GetRelativePath(
-            sampleSolutionDir,
-            csproj.Destination.FullName
-        );
-
-        var restProjectSampleSources = sampleSources
-            .Where(static (kv) => !StringComparer.OrdinalIgnoreCase.Equals(kv.Key, ".cs"))
-            .SelectMany(static (kv) => kv.Value);
-
-        return (csprojRelativePath, [csproj, ..restProjectSampleSources]);
-    }
-
-    static IEnumerable<MappedFileSource> PrepareSampleSources(
-        TaskLoggingHelper log,
-        IEnumerable<AllureSample> samples,
-        string greatestCommonPrefix,
-        string sampleProjectDir
-    ) =>
-        samples
-            .Select((sample) =>
-                PrepareSampleSource(log, sampleProjectDir, greatestCommonPrefix, sample))
-            .Where(static (sample) => sample is not null);
-
-
-    static MappedFileSource PrepareSampleSource(
-        TaskLoggingHelper log,
-        string sampleProjectDir,
-        string greatestCommonPrefix,
-        AllureSample sample
-    )
-    {
-        var absolutePath = sample.Path;
-        var relativeSampleFilePath = Path.GetRelativePath(greatestCommonPrefix, absolutePath);
-        if (relativeSampleFilePath.StartsWith($"..{Path.DirectorySeparatorChar}"))
-        {
-            Logging.LogFileOutsideProjectWarning(
-                log,
-                sampleProjectDir,
-                absolutePath,
-                relativeSampleFilePath
-            );
-            return null;
-        }
-        else
-        {
-            var destination = Path.Combine(sampleProjectDir, relativeSampleFilePath);
-            return new (absolutePath, destination);
-        }
-    }
 
     static IEnumerable<(string key, string value)> GetSampleProjectProperties(
         IEnumerable<AllureSample> sampleSources

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -18,7 +18,7 @@ public static class Projects
         string testProjectDirectory,
         string testProjectRootNamespace,
         ImmutableDictionary<string, string> itemTypeMap,
-        IEnumerable<ITaskItem2> sampleSources
+        IEnumerable<ITaskItem> sampleSources
     ) =>
         [
             ..sampleSources
@@ -41,7 +41,7 @@ public static class Projects
         string testProjectDirectory,
         string testProjectRootNamespace,
         ImmutableDictionary<string, string> itemTypeMap,
-        ITaskItem2 sample
+        ITaskItem sample
     )
     {
         var path = GetSamplePath(log, testProjectDirectory, sample);
@@ -109,7 +109,7 @@ public static class Projects
     static string GetSamplePath(
         TaskLoggingHelper log,
         string basePath,
-        ITaskItem2 sample
+        ITaskItem sample
     )
     {
         var path = sample.ItemSpec;
@@ -132,7 +132,7 @@ public static class Projects
     static string GetSampleName(
         TaskLoggingHelper log,
         string testProjectDirectory,
-        ITaskItem2 sample
+        ITaskItem sample
     )
     {
         var sampleName = GetSampleMetadata(log, sample, "SampleName");
@@ -153,7 +153,7 @@ public static class Projects
         TaskLoggingHelper log,
         string testProjectDirectory,
         string testProjectRootNamespace,
-        ITaskItem2 sample
+        ITaskItem sample
     )
     {
         var registryNamespace = GetSampleMetadata(log, sample, "RegistryNamespace");
@@ -171,9 +171,9 @@ public static class Projects
         return registryNamespace;
     }
 
-    static string GetSampleMetadata(TaskLoggingHelper log, ITaskItem2 sample, string metadataKey)
+    static string GetSampleMetadata(TaskLoggingHelper log, ITaskItem sample, string metadataKey)
     {
-        var value = sample.GetMetadataValueEscaped(metadataKey);
+        var value = sample.GetMetadata(metadataKey);
         if (string.IsNullOrEmpty(value))
         {
             Logging.LogNoMetadata(log, sample, metadataKey);
@@ -184,11 +184,11 @@ public static class Projects
     }
 
     static ImmutableArray<(string key, string value)> GetSampleSpecificProperties(
-        ITaskItem2 sample
+        ITaskItem sample
     )
         => [
             .. sample
-                .GetMetadataValueEscaped("Properties")
+                .GetMetadata("Properties")
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
                 .Select(static (p) => p.Split('=', StringSplitOptions.RemoveEmptyEntries))
                 .Where(static (p) => p.Length == 2)

--- a/build/Allure.Build.Tasks/Functions/XmlDefinitions.cs
+++ b/build/Allure.Build.Tasks/Functions/XmlDefinitions.cs
@@ -8,6 +8,9 @@ using Microsoft.CodeAnalysis;
 
 namespace Allure.Build.Tasks.Functions;
 
+using ProjectFileData =
+    (string itemType, IEnumerable<(string path, ImmutableArray<(string key, string value)> metadata)> items);
+
 public static class XmlDefinitions
 {
     public static XDocument DirectorySolutionTarget { get; }
@@ -37,10 +40,10 @@ public static class XmlDefinitions
             )
         );
 
-    public static XDocument Solution(IEnumerable<string> projectFileRelativePaths) => new(
+    public static XDocument Solution(IEnumerable<string> sampleSolutionRelativeProjectPath) => new(
         new XElement(
             "Solution",
-            projectFileRelativePaths.Select(static (file) => new XElement(
+            sampleSolutionRelativeProjectPath.Select(static (file) => new XElement(
                 "Project",
                 new XAttribute("Path", file)
             ))
@@ -48,19 +51,21 @@ public static class XmlDefinitions
     );
 
     public static XDocument Project(
-        IEnumerable<(string key, string value)> properties,
-        IEnumerable<string> compile
+        IEnumerable<(string key, string value)> projectProperties,
+        IEnumerable<ProjectFileData> groupedProjectItems
     ) => new(
         new XElement(
             "Project",
             (object[])[
                 new XAttribute("Sdk", "Microsoft.NET.Sdk"),
-                ..MapNotEmpty(properties, static (props) => MsBuild.GetPropertyGroup(props)),
-                ..MapNotEmpty(compile, static (paths) => MsBuild.GetItemGroup(
-                    paths,
-                    "Compile",
-                    static (p) => [("Include", p)])
-                )
+                ..Collections.MapNotEmpty(projectProperties, static (props) => MsBuild.GetPropertyGroup(props)),
+                ..groupedProjectItems
+                    .Select(static (group) => MsBuild.GetItemGroup(
+                        group.items,
+                        group.itemType,
+                        static (f) => [("Include", f.path), ..f.metadata]
+                    )
+                ),
             ]
         )
     );
@@ -71,7 +76,7 @@ public static class XmlDefinitions
             new XElement(
                 "configuration",
                 (object[])[
-                    ..MapNotEmpty(packageCacheLocation, static (path) => new XElement(
+                    ..Collections.MapNotEmpty(packageCacheLocation, static (path) => new XElement(
                         "config",
                         new XElement(
                             "add",
@@ -120,17 +125,17 @@ public static class XmlDefinitions
                 MsBuild.GetItemGroup("Clean", [
                     ("Include", Path.Combine("$(TargetDir)allure-results", "**", "*"))
                 ]),
-                ..MapNotEmpty(packages, static (packages) => MsBuild.GetItemGroup(
+                ..Collections.MapNotEmpty(packages, static (packages) => MsBuild.GetItemGroup(
                     packages,
                     "PackageReference",
                     static (p) => [("Include", p)]
                 )),
-                ..MapNotEmpty(projects, static (projects) => MsBuild.GetItemGroup(
+                ..Collections.MapNotEmpty(projects, static (projects) => MsBuild.GetItemGroup(
                     projects,
                     "ProjectReference",
                     static (p) => [("Include", MsBuild.NormalizeToThisFileDirectory(p))]
                 )),
-                ..MapNotEmpty(analyzerProjects, static (projects) => MsBuild.GetItemGroup(
+                ..Collections.MapNotEmpty(analyzerProjects, static (projects) => MsBuild.GetItemGroup(
                     projects,
                     "ProjectReference",
                     static (p) => [
@@ -168,15 +173,4 @@ public static class XmlDefinitions
             ]
         )
     );
-
-    public static IEnumerable<R> MapNotEmpty<T, R>(IEnumerable<T> sequence, Func<IEnumerable<T>, R> map) =>
-        sequence.ToImmutableArray() is { IsEmpty: false } array
-            ? [map(array)]
-            : [];
-
-    public static IEnumerable<R> MapNotEmpty<R>(string value, Func<string, R> map) =>
-        string.IsNullOrEmpty(value)
-            ? []
-            : [map(value)];
-
 }

--- a/build/Allure.Build.Tasks/Functions/XmlDefinitions.cs
+++ b/build/Allure.Build.Tasks/Functions/XmlDefinitions.cs
@@ -48,13 +48,19 @@ public static class XmlDefinitions
     );
 
     public static XDocument Project(
-        IEnumerable<(string key, string value)> properties
+        IEnumerable<(string key, string value)> properties,
+        IEnumerable<string> compile
     ) => new(
         new XElement(
             "Project",
             (object[])[
                 new XAttribute("Sdk", "Microsoft.NET.Sdk"),
                 ..MapNotEmpty(properties, static (props) => MsBuild.GetPropertyGroup(props)),
+                ..MapNotEmpty(compile, static (paths) => MsBuild.GetItemGroup(
+                    paths,
+                    "Compile",
+                    static (p) => [("Include", p)])
+                )
             ]
         )
     );

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -12,9 +12,6 @@ namespace Allure.Build.Tasks;
 public class GenerateSampleSolution : Task
 {
     [Required]
-    public ITaskItem[] SampleItemTypes { get; set; }
-
-    [Required]
     public ITaskItem[] SampleSources { get; set; }
 
     [Required]
@@ -46,10 +43,16 @@ public class GenerateSampleSolution : Task
 
     public string PackageCacheDirectory { get; set; }
 
+    IEnumerable<ITaskItem2> SampleSources2 => this.SampleSources.Cast<ITaskItem2>();
+
+    IEnumerable<ITaskItem2> SamplePackageReferences2 =>
+        this.SamplePackageReferences.Cast<ITaskItem2>();
+
     IEnumerable<string> CommonPackageNames =>
-        from x in this.SamplePackageReferences
+        from x in this.SamplePackageReferences2
         where x.GetMetadata("Optional").ToLower() is "" or not "true"
-        select x.ItemSpec;
+        // Keep escaping as we will write it as the Include attribute value.
+        select x.EvaluatedIncludeEscaped;
 
     IEnumerable<string> AnalyzerPathsRelativeToSolutionDir =>
         this.SampleProjectReferences
@@ -62,18 +65,6 @@ public class GenerateSampleSolution : Task
                     this.SampleSolutionDir
                 ))
             );
-
-
-    public ImmutableDictionary<string, string> SampleItemTypeMap =>
-        this.SampleItemTypes.ToImmutableDictionary(
-            static (m) => m.ItemSpec,
-            static (m) => m.GetMetadata("ItemType") is { Length: >0 } itemType
-                ? itemType
-                : "None",
-            StringComparer.OrdinalIgnoreCase,
-            StringComparer.Ordinal
-        );
-
 
     static internal TaskLoggingHelper log;
 
@@ -133,8 +124,13 @@ public class GenerateSampleSolution : Task
     GeneratedFileSource PrepareDirectoryPackagesProps() =>
         Files.DirectoryPackagesProps(
             this.SampleSolutionDir,
-            this.SamplePackageReferences.Select(
-                static (item) => (item.ItemSpec, item.GetMetadata("Version"))
+            this.SamplePackageReferences2.Select(
+                static (item) => (
+                    // Keep escape as we're writing these values to Directory.Package.props
+                    // and the project file as is.
+                    name: item.EvaluatedIncludeEscaped,
+                    varsion: item.GetMetadataValueEscaped("Version")
+                )
             )
         );
 
@@ -151,7 +147,6 @@ public class GenerateSampleSolution : Task
             this.SampleSolutionDir,
             this.ProjectDirectory,
             this.RootNamespace,
-            this.SampleItemTypeMap,
             this.SampleSources
         );
 

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -46,24 +46,13 @@ public class GenerateSampleSolution : Task
 
     public string PackageCacheDirectory { get; set; }
 
-    IEnumerable<ITaskItem2> SampleSources2 =>
-        this.SampleSources.Cast<ITaskItem2>();
-
-    IEnumerable<ITaskItem2> SamplePackageReferences2 =>
-        this.SamplePackageReferences.Cast<ITaskItem2>();
-
-    IEnumerable<ITaskItem2> SampleProjectReferences2 =>
-        this.SampleProjectReferences.Cast<ITaskItem2>();
-
-    IEnumerable<ITaskItem2> CommonPackageReferences =>
-        this.SamplePackageReferences2.Where(static (spec) =>
-        {
-            var optional = spec.GetMetadataValueEscaped("Optional");
-            return string.IsNullOrEmpty(optional) || optional.ToLower() is not "true";
-        });
+    IEnumerable<string> CommonPackageNames =>
+        from x in this.SamplePackageReferences
+        where x.GetMetadata("Optional").ToLower() is "" or not "true"
+        select x.ItemSpec;
 
     IEnumerable<string> AnalyzerPathsRelativeToSolutionDir =>
-        this.SampleProjectReferences2
+        this.SampleProjectReferences
             .SelectMany((item) => item
                 .GetMetadata("AnalyzerProjects")
                 .Split(';', StringSplitOptions.RemoveEmptyEntries)
@@ -120,7 +109,7 @@ public class GenerateSampleSolution : Task
             this.Log,
             this.SampleSolutionDir,
             this.ProjectDirectory,
-            this.SampleProjectReferences2
+            this.SampleProjectReferences
         );
 
     GeneratedFileSource PrepareDirectorySolutionTargets() =>
@@ -131,7 +120,7 @@ public class GenerateSampleSolution : Task
             solutionDir: this.SampleSolutionDir,
             targetFrameworks: this.SampleTargetFrameworks,
             imports.PropsFiles,
-            packages: this.CommonPackageReferences.Select(static (item) => item.ItemSpec),
+            packages: this.CommonPackageNames,
             projects: this.SampleProjectReferences.Select((item) =>
                 Files.RebasePath(item.ItemSpec, this.ProjectDirectory, this.SampleSolutionDir)
             ),
@@ -144,7 +133,7 @@ public class GenerateSampleSolution : Task
     GeneratedFileSource PrepareDirectoryPackagesProps() =>
         Files.DirectoryPackagesProps(
             this.SampleSolutionDir,
-            this.SamplePackageReferences2.Select(
+            this.SamplePackageReferences.Select(
                 static (item) => (item.ItemSpec, item.GetMetadata("Version"))
             )
         );
@@ -163,7 +152,7 @@ public class GenerateSampleSolution : Task
             this.ProjectDirectory,
             this.RootNamespace,
             this.SampleItemTypeMap,
-            this.SampleSources2
+            this.SampleSources
         );
 
     GeneratedFileSource PrepareSolutionFile(IEnumerable<GeneratedFileSource> csprojFiles) =>

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
 using Allure.Build.Tasks.Functions;
-using Allure.Build.Tasks.Sources;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -12,6 +11,9 @@ namespace Allure.Build.Tasks;
 
 public class GenerateSampleSolution : Task
 {
+    [Required]
+    public ITaskItem[] SampleItemTypes { get; set; }
+
     [Required]
     public ITaskItem[] SampleSources { get; set; }
 
@@ -72,6 +74,18 @@ public class GenerateSampleSolution : Task
                 ))
             );
 
+
+    public ImmutableDictionary<string, string> SampleItemTypeMap =>
+        this.SampleItemTypes.ToImmutableDictionary(
+            static (m) => m.ItemSpec,
+            static (m) => m.GetMetadata("ItemType") is { Length: >0 } itemType
+                ? itemType
+                : "None",
+            StringComparer.OrdinalIgnoreCase,
+            StringComparer.Ordinal
+        );
+
+
     static internal TaskLoggingHelper log;
 
     public override bool Execute()
@@ -84,8 +98,8 @@ public class GenerateSampleSolution : Task
         var directoryBuildTargets = this.PrepareDirectoryBuildTargets(imports);
         var directoryPackagesProps = this.PrepareDirectoryPackagesProps();
         var nugetConfig = this.PrepareNugetConfig();
-        var (csprojRelativePaths, projectFiles) = this.PrepareProjects();
-        var slnx = this.PrepareSolutionFile(csprojRelativePaths);
+        var projectFiles = this.PrepareProjects();
+        var slnx = this.PrepareSolutionFile(projectFiles);
 
         FileProcessor.CommitSampleFiles(this.Log, this.SampleSolutionDir, [
             slnx,
@@ -142,15 +156,19 @@ public class GenerateSampleSolution : Task
             this.SampleSolutionDir
         );
 
-    (ImmutableArray<string> paths, ImmutableArray<FileSource> sources) PrepareProjects() =>
+    ImmutableArray<GeneratedFileSource> PrepareProjects() =>
         Projects.GenerateProjects(
             this.Log,
             this.SampleSolutionDir,
             this.ProjectDirectory,
             this.RootNamespace,
+            this.SampleItemTypeMap,
             this.SampleSources2
         );
 
-    GeneratedFileSource PrepareSolutionFile(IEnumerable<string> projectPaths) =>
-        Files.Solution(this.SampleSolutionPath, projectPaths);
+    GeneratedFileSource PrepareSolutionFile(IEnumerable<GeneratedFileSource> csprojFiles) =>
+        Files.Solution(
+            this.SampleSolutionPath,
+            csprojFiles.Select(static (f) => f.Destination.FullName)
+        );
 }

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
 using Allure.Build.Tasks.Functions;
@@ -152,7 +153,9 @@ public class GenerateSampleSolution : Task
 
     GeneratedFileSource PrepareSolutionFile(IEnumerable<GeneratedFileSource> csprojFiles) =>
         Files.Solution(
-            this.SampleSolutionPath,
-            csprojFiles.Select(static (f) => f.Destination.FullName)
+            solutionFilePath: this.SampleSolutionPath,
+            sampleSolutionRelativeProjectPath: csprojFiles.Select((f) =>
+                Path.GetRelativePath(this.SampleSolutionDir, f.Destination.FullName)
+            )
         );
 }

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -147,7 +147,7 @@ public class GenerateSampleSolution : Task
             this.SampleSolutionDir,
             this.ProjectDirectory,
             this.RootNamespace,
-            this.SampleSources
+            this.SampleSources2
         );
 
     GeneratedFileSource PrepareSolutionFile(IEnumerable<GeneratedFileSource> csprojFiles) =>

--- a/build/Allure.Build.Tasks/ResolveRegistryEntries.cs
+++ b/build/Allure.Build.Tasks/ResolveRegistryEntries.cs
@@ -38,16 +38,13 @@ public class ResolveRegistryEntries : Task
     [Output]
     public ITaskItem[] Entries { get; set; }
 
-    IEnumerable<ITaskItem2> SampleFiles2 =>
-        this.SampleFiles.Cast<ITaskItem2>();
-
     bool success = false;
 
     public override bool Execute()
     {
         this.success = true;
 
-        var registryDescriptors = this.SampleFiles2
+        var registryDescriptors = this.SampleFiles
             .Select(this.CreateSampleFile)
             .Where(static file => file is not null)
             .GroupBy(
@@ -69,9 +66,9 @@ public class ResolveRegistryEntries : Task
         return this.success;
     }
 
-    SampleFile CreateSampleFile(ITaskItem2 item)
+    SampleFile CreateSampleFile(ITaskItem item)
     {
-        var registryNamespace = item.GetMetadataValueEscaped("RegistryNamespace");
+        var registryNamespace = item.GetMetadata("RegistryNamespace");
         if (string.IsNullOrEmpty(registryNamespace))
         {
             Logging.LogResolveRegistryEntryNoMetadata(this.Log, item, "RegistryNamespace");
@@ -86,7 +83,7 @@ public class ResolveRegistryEntries : Task
             return null;
         }
 
-        var sampleName = item.GetMetadataValueEscaped("SampleName");
+        var sampleName = item.GetMetadata("SampleName");
         if (string.IsNullOrEmpty(sampleName))
         {
             Logging.LogResolveRegistryEntryNoMetadata(this.Log, item, "SampleName");
@@ -101,7 +98,7 @@ public class ResolveRegistryEntries : Task
             return null;
         }
 
-        var projectRelativePath = item.GetMetadataValueEscaped("ProjectRelativePath");
+        var projectRelativePath = item.GetMetadata("ProjectRelativePath");
         if (string.IsNullOrEmpty(projectRelativePath))
         {
             Logging.LogResolveRegistryEntryNoMetadata(this.Log, item, "ProjectRelativePath");
@@ -109,7 +106,7 @@ public class ResolveRegistryEntries : Task
             return null;
         }
 
-        var projectFilePath = item.GetMetadataValueEscaped("ProjectFilePath");
+        var projectFilePath = item.GetMetadata("ProjectFilePath");
         if (string.IsNullOrEmpty(projectFilePath))
         {
             Logging.LogResolveRegistryEntryNoMetadata(this.Log, item, "ProjectFilePath");
@@ -117,7 +114,7 @@ public class ResolveRegistryEntries : Task
             return null;
         }
 
-        var resultsDirectory = item.GetMetadataValueEscaped("ResultsDirectory");
+        var resultsDirectory = item.GetMetadata("ResultsDirectory");
         if (string.IsNullOrEmpty(resultsDirectory))
         {
             Logging.LogResolveRegistryEntryNoMetadata(this.Log, item, "ResultsDirectory");
@@ -126,7 +123,7 @@ public class ResolveRegistryEntries : Task
         }
 
         return new(
-            Path: item.EvaluatedIncludeEscaped,
+            Path: item.ItemSpec,
             RegistryNamespace: registryNamespace,
             SampleName: sampleName,
             ProjectRelativePath: projectRelativePath,

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -115,25 +115,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <AllureSample Include="**/Samples/**/*" Exclude="**/.*" />
-
-        <!-- To add or overwrite metadata, prefix it with Sample_:
-
-         <AllureSample Include="foo.bar" Sample_CopyToOutputDirectory="Never" />
-         -->
-    </ItemGroup>
-
-    <ItemGroup>
-        <!-- Include .cs files as Compile items-->
-        <AllureSampleItemType Include=".cs" ItemType="Compile" />
-
-        <!-- Add a new in .csproj to create a project-specific association.
-         For example:
-
-         <AllureSampleItemType Include=".feature" ItemType="ReqnrollFeatureFiles" />
-
-         Unmatched sample files are included as <None Include="<path>" CopyToOutputDirectory="PreserveNewest" />
-         -->
+        <!-- We're only including .cs samples by default. Other files needs to be included on a
+         per-project basis.
+        Each AllureSample becomes an item in the generated sample project. The item includes
+         the original sample file. You can control the item type by applying ItemType="...".
+         Use Properties="..." to provide extra MSBuild properties to the generated project.
+         Use ItemMetadata="..." to provide metadata to the item created for this sample. -->
+        <AllureSample Include="**/Samples/**/*.cs" Exclude="**/.*" ItemType="Compile" />
     </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -116,6 +116,24 @@
 
     <ItemGroup>
         <AllureSample Include="**/Samples/**/*" Exclude="**/.*" />
+
+        <!-- To add or overwrite metadata, prefix it with Sample_:
+
+         <AllureSample Include="foo.bar" Sample_CopyToOutputDirectory="Never" />
+         -->
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- Include .cs files as Compile items-->
+        <AllureSampleItemType Include=".cs" ItemType="Compile" />
+
+        <!-- Add a new in .csproj to create a project-specific association.
+         For example:
+
+         <AllureSampleItemType Include=".feature" ItemType="ReqnrollFeatureFiles" />
+
+         Unmatched sample files are included as <None Include="<path>" CopyToOutputDirectory="PreserveNewest" />
+         -->
     </ItemGroup>
 
 </Project>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -196,6 +196,7 @@
         <MakeDir Directories="$(Allure_LocalNugetRepository)" />
 
         <Allure.Build.Tasks.GenerateSampleSolution
+            SampleItemTypes="@(AllureSampleItemType)"
             SampleSources="@(_Allure_ResolvedSample)"
             SamplePackageReferences="@(SamplePackageReference)"
             SampleProjectReferences="@(SampleProjectReference)"

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -196,7 +196,6 @@
         <MakeDir Directories="$(Allure_LocalNugetRepository)" />
 
         <Allure.Build.Tasks.GenerateSampleSolution
-            SampleItemTypes="@(AllureSampleItemType)"
             SampleSources="@(_Allure_ResolvedSample)"
             SamplePackageReferences="@(SamplePackageReference)"
             SampleProjectReferences="@(SampleProjectReference)"


### PR DESCRIPTION
### Context

This PR removes redundant file copies. Instead of copying each sample file to the project directory and including the copy to the build (explicitly or implicitly), the sample generator now includes the original files directly.

So we're moving from roughly this:

```
  - test project
      - samples
          - sample-1
              - sample-1 file
  - sample solution for test project
      - sample project for sample-1: `<Compile Include="<path to the copy of sample-1 file>" />`
          - copy of sample-1 file
```

To something that is more like this:

```
  - test project
      - samples
          - sample-1
              - sample-1 file
  - sample solution for test project
      - sample project for sample-1: `<Compile Include="<path to the original sample-1 file>" />`
```

The benefits:

  - less copying involved
  - fewer issues with stale files
  - there is only one file to update: accidental changes to the copy won't get lost.

The item type and metadata can be configured:

```xml
<AllureSample Include="./features/**/*.feature" ItemType="ReqnrollFeatureFiles" ItemMetadata="CopyToOutputDirectory=Never;Foo=Bar" />
```

The PR also changes the default sample files to match `**/*.cs`. I.e., only C# source files are considered sample files by default. Samples of other types need to be included on a per-project basis.

If the type is unknown, the generator will emit `<None Include="path" CopyToOutputDirectory="PreserveNewest" />`, which seems to be a reasonable default.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
