### PR TITLE
Support integration testing of MTP-based integrations

### DIFF
--- a/build/Allure.Build.SourceGenerators/AllureMsbuildPropsGenerator.cs
+++ b/build/Allure.Build.SourceGenerators/AllureMsbuildPropsGenerator.cs
@@ -12,7 +12,7 @@ namespace Allure.Build.SourceGenerators;
 using AllureBuildPropertiesData = ImmutableArray<(string, string)>;
 
 [Generator]
-public class AllureMsbuildPropsGenerator : IIncrementalGenerator
+public sealed class AllureMsbuildPropsGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {

--- a/build/Allure.Build.SourceGenerators/AllureSampleRegistryGenerator.cs
+++ b/build/Allure.Build.SourceGenerators/AllureSampleRegistryGenerator.cs
@@ -178,6 +178,18 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
                 /// </remarks>
                 public static {{ Constants.REGISTRY_ENTRY_CLASSNAME_FULL }} {{ sampleName }} { get; }
                     = new(
+                        TestingPlatform: {{ Constants.MSBUILD_PROPS_CLASSNAME_FULL }}.{{ Constants.PROP_TESTING_PLATFORM }} switch
+                        {
+                            null or "" or {{ SymbolDisplay.FormatLiteral(Constants.TESTING_PLATFORM_VSTEST, true) }} =>
+                                {{ Constants.TESTING_PLATFORM_VSTEST_FULL }},
+
+                            {{ SymbolDisplay.FormatLiteral(Constants.TESTING_PLATFORM_MTP, true) }} =>
+                                {{ Constants.TESTING_PLATFORM_MTP_FULL }},
+
+                            var value => throw new {{ Constants.ARGUMENT_EXCEPTION_CLASSNAME_FULL }}(
+                                $"The testing platform value '{value}' is not supported."
+                            ),
+                        },
                         RegistryId: "{{ registryNamespace }}",
                         SampleId: "{{ sampleName }}",
                         ProjectFilePath: {{ SymbolDisplay.FormatLiteral(projectFilePath, true) }},

--- a/build/Allure.Build.SourceGenerators/Assertions/AllureAssertionsGenerator.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/AllureAssertionsGenerator.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Allure.Build.SourceGenerators.Assertions;
 
 [Generator]
-public class AllureAssertionsGenerator : IIncrementalGenerator
+public sealed class AllureAssertionsGenerator : IIncrementalGenerator
 {
     static readonly SymbolDisplayFormat FullyQualifiedNoTypeParameters = new(
         globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Included,

--- a/build/Allure.Build.SourceGenerators/Assertions/AttributeDefinitions.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/AttributeDefinitions.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public static class AttributeDefinitions
+static class AttributeDefinitions
 {
     public const string GenerateAllureAssertionsAttribute =
         """

--- a/build/Allure.Build.SourceGenerators/Assertions/AttributeProperties.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/AttributeProperties.cs
@@ -3,7 +3,7 @@ using Microsoft.CodeAnalysis;
 
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public record class AttributeProperties(
+sealed record class AttributeProperties(
     string PropertyName,
     string MethodName,
     string JsonName,

--- a/build/Allure.Build.SourceGenerators/Assertions/Attributes.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/Attributes.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public static class Attributes
+static class Attributes
 {
     public static string CallerArgumentExpressionFor(string parameter) =>
         $"[{Types.CallerArgumentExpression}(nameof({parameter}))]";

--- a/build/Allure.Build.SourceGenerators/Assertions/CollectionOfCollectionsPropertyMetadata.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/CollectionOfCollectionsPropertyMetadata.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public record class CollectionOfCollectionsPropertyMetadata(
+sealed record class CollectionOfCollectionsPropertyMetadata(
     string InterfaceName,
     string InterfaceFullName,
     string Name,

--- a/build/Allure.Build.SourceGenerators/Assertions/CollectionPropertyMetadata.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/CollectionPropertyMetadata.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public record class CollectionPropertyMetadata(
+record class CollectionPropertyMetadata(
     string InterfaceName,
     string InterfaceFullName,
     string Name,

--- a/build/Allure.Build.SourceGenerators/Assertions/MethodNames.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/MethodNames.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public record class MethodNames(
+sealed record class MethodNames(
     string NoProperty,
     string PropertyExistsAnyValue,
     string PropertyEquatable,

--- a/build/Allure.Build.SourceGenerators/Assertions/Methods.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/Methods.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public static class Methods
+static class Methods
 {
     public static string NoProperty(string methodName, PropertyMetadata property) =>
         $$"""

--- a/build/Allure.Build.SourceGenerators/Assertions/PropertyMetadata.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/PropertyMetadata.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public record class PropertyMetadata(
+record class PropertyMetadata(
     string InterfaceName,
     string InterfaceFullName,
     string Name,

--- a/build/Allure.Build.SourceGenerators/Assertions/Types.cs
+++ b/build/Allure.Build.SourceGenerators/Assertions/Types.cs
@@ -1,6 +1,6 @@
 namespace Allure.Build.SourceGenerators.Assertions;
 
-public static class Types
+static class Types
 {
     public const string CallerArgumentExpression =
         $"global::System.Runtime.CompilerServices.CallerArgumentExpression";

--- a/build/Allure.Build.SourceGenerators/Constants.cs
+++ b/build/Allure.Build.SourceGenerators/Constants.cs
@@ -2,8 +2,15 @@ namespace Allure.Build.SourceGenerators;
 
 internal static class Constants
 {
+    public const string ARGUMENT_EXCEPTION_CLASSNAME_FULL = "global::System.ArgumentException";
     public const string NAMESPACE_NAME = "Allure.Testing";
     public const string EXECUTION_NAMESPACE_NAME = $"{NAMESPACE_NAME}.Execution";
+    public const string TESTING_PLATFORM_ENUM_NAME = "TestingPlatform";
+    public const string TESTING_PLATFORM_ENUM_NAME_FULL = $"global::{EXECUTION_NAMESPACE_NAME}.TestingPlatform";
+    public const string TESTING_PLATFORM_VSTEST = $"VsTest";
+    public const string TESTING_PLATFORM_VSTEST_FULL = $"{TESTING_PLATFORM_ENUM_NAME_FULL}.{TESTING_PLATFORM_VSTEST}";
+    public const string TESTING_PLATFORM_MTP = $"MicrosoftTestingPlatform";
+    public const string TESTING_PLATFORM_MTP_FULL = $"{TESTING_PLATFORM_ENUM_NAME_FULL}.{TESTING_PLATFORM_MTP}";
     public const string MSBUILD_PROPS_FILENAME = "AllureBuildProperties.g.cs";
     public const string MSBUILD_PROPS_CLASSNAME = "AllureBuildProperties";
     public const string MSBUILD_PROPS_CLASSNAME_FULL = $"global::{NAMESPACE_NAME}.{MSBUILD_PROPS_CLASSNAME}";
@@ -18,6 +25,7 @@ internal static class Constants
     public const string RESULTS_DIRECTORY_METADATA_NAME = "build_metadata.AdditionalFiles.Allure_ResultsDirectory";
     public const string RUNNER_CLASSNAME = "AllureSampleRunner";
     public const string RUNNER_CLASSNAME_FULL = $"global::{NAMESPACE_NAME}.{RUNNER_CLASSNAME}";
+    public const string PROP_TESTING_PLATFORM = "Allure_TestingPlatform";
     public const string PROP_TARGET_FRAMEWORK = "Allure_SampleSelectedTargetFramework";
     public const string PROP_CONFIGURATION = "Allure_SampleConfiguration";
     public const string PROP_PRERUN_FLOW = "Allure_PreRunTestingFlow";

--- a/build/Allure.Build.SourceGenerators/Constants.cs
+++ b/build/Allure.Build.SourceGenerators/Constants.cs
@@ -3,11 +3,12 @@ namespace Allure.Build.SourceGenerators;
 internal static class Constants
 {
     public const string NAMESPACE_NAME = "Allure.Testing";
+    public const string EXECUTION_NAMESPACE_NAME = $"{NAMESPACE_NAME}.Execution";
     public const string MSBUILD_PROPS_FILENAME = "AllureBuildProperties.g.cs";
     public const string MSBUILD_PROPS_CLASSNAME = "AllureBuildProperties";
     public const string MSBUILD_PROPS_CLASSNAME_FULL = $"global::{NAMESPACE_NAME}.{MSBUILD_PROPS_CLASSNAME}";
     public const string REGISTRY_ENTRY_CLASSNAME = "AllureSampleRegistryEntry";
-    public const string REGISTRY_ENTRY_CLASSNAME_FULL = $"global::{NAMESPACE_NAME}.{REGISTRY_ENTRY_CLASSNAME}";
+    public const string REGISTRY_ENTRY_CLASSNAME_FULL = $"global::{EXECUTION_NAMESPACE_NAME}.{REGISTRY_ENTRY_CLASSNAME}";
     public const string REGISTRY_CLASSNAME = "AllureSampleRegistry";
     public const string REGISTRY_FILENAME = "AllureSampleRegistry.g.cs";
     public const string SAMPLE_NAME_METADATA_NAME = "build_metadata.AdditionalFiles.Allure_SampleName";

--- a/build/Allure.Build.SourceGenerators/Samples/AllureSampleRegistryGenerator.cs
+++ b/build/Allure.Build.SourceGenerators/Samples/AllureSampleRegistryGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -7,22 +8,20 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace Allure.Build.SourceGenerators;
-
-using SampleRegistryArray = ImmutableArray<(string, ImmutableArray<SampleRegistryEntry>)>;
+namespace Allure.Build.SourceGenerators.Samples;
 
 [Generator]
-public class AllureSampleRegistryGenerator : IIncrementalGenerator
+public sealed class AllureSampleRegistryGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        IncrementalValueProvider<SampleRegistryArray> sampleSourceStream
+        IncrementalValuesProvider<RegistrySource> sampleSourceStream
             = SetupGroupedSampleSourcesStream(context);
 
-        context.RegisterSourceOutput(sampleSourceStream, GenerateSampleRegistries);
+        context.RegisterSourceOutput(sampleSourceStream, GenerateSampleRegistry);
     }
 
-    static IncrementalValueProvider<SampleRegistryArray> SetupGroupedSampleSourcesStream(
+    static IncrementalValuesProvider<RegistrySource> SetupGroupedSampleSourcesStream(
         IncrementalGeneratorInitializationContext context
     ) =>
         context.AdditionalTextsProvider
@@ -30,9 +29,11 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
             .Select(ReadSampleMetadata)
             .Where(static (sample) => sample is not null)
             .Collect()
-            .Select(GroupSampleSourcesByRegistry!);
+            .Select(GroupAndSortEntries!)
+            .SelectMany(static (registries, _) => registries)
+            .WithComparer(RegistrySourceComparer.Instance);
 
-    static SampleRegistryEntry? ReadSampleMetadata(
+    static RegistryEntry? ReadSampleMetadata(
         (AdditionalText Left, AnalyzerConfigOptionsProvider Right) pair,
         CancellationToken _
     )
@@ -45,7 +46,7 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
             && opts.TryGetValue(Constants.PROJECT_RELATIVE_PATH_METADATA_NAME, out var projectRelativePath)
             && opts.TryGetValue(Constants.RESULTS_DIRECTORY_METADATA_NAME, out var resultsDirectory))
         {
-            return new SampleRegistryEntry(
+            return new RegistryEntry(
                 RegistryNamespace: registryNamespace,
                 SampleName: sampleName,
                 SourcePath: pair.Left.Path,
@@ -57,38 +58,32 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
         return null;
     }
 
-    static SampleRegistryArray GroupSampleSourcesByRegistry(
-        ImmutableArray<SampleRegistryEntry> registryEntries,
+    static ImmutableArray<RegistrySource> GroupAndSortEntries(
+        ImmutableArray<RegistryEntry> registryEntries,
         CancellationToken _
     ) =>
         [
             .. registryEntries
                 .GroupBy(
                     static (sample) => sample.RegistryNamespace,
-                    static (registryNamespace, registrySamples) => (
+                    static (registryNamespace, registrySamples) => new RegistrySource(
                         registryNamespace,
-                        registrySamples.ToImmutableArray()
-                    )
+                        [
+                            .. registrySamples
+                                .OrderBy(static (sample) => sample.SampleName, StringComparer.Ordinal)
+                        ]
+                    ),
+                    StringComparer.Ordinal
                 )
+                .OrderBy(static registry => registry.Namespace, StringComparer.Ordinal)
         ];
-
-    static void GenerateSampleRegistries(
-        SourceProductionContext productionContext,
-        SampleRegistryArray sampleRegistries
-    )
-    {
-        foreach (var (registryNamespace, registryEntries) in sampleRegistries)
-        {
-            GenerateSampleRegistry(productionContext, registryNamespace, registryEntries);
-        }
-    }
 
     static void GenerateSampleRegistry(
         SourceProductionContext productionContext,
-        string registryNamespace,
-        ImmutableArray<SampleRegistryEntry> registryEntries
+        RegistrySource sampleRegistry
     )
     {
+        var (registryNamespace, registryEntries) = sampleRegistry;
         var code = GetSampleRegistryCode(registryNamespace, registryEntries);
         var path = Path.Combine(registryNamespace, Constants.REGISTRY_FILENAME);
         productionContext.AddSource(path, code);
@@ -96,7 +91,7 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
 
     static string GetSampleRegistryCode(
         string registryNamespace,
-        ImmutableArray<SampleRegistryEntry> entries
+        ImmutableArray<RegistryEntry> entries
     )
     {
         var sb = new StringBuilder();
@@ -109,7 +104,7 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
     static void AppendRegistryClass(
         StringBuilder sb,
         string registryNamespace,
-        ImmutableArray<SampleRegistryEntry> entries
+        ImmutableArray<RegistryEntry> entries
     )
     {
         sb.Append(
@@ -133,7 +128,7 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
     static void AppendRegistryEntryProperties(
         StringBuilder sb,
         string registryNamespace,
-        ImmutableArray<SampleRegistryEntry> entries
+        ImmutableArray<RegistryEntry> entries
     )
     {
         if (entries.Length > 0)
@@ -151,7 +146,7 @@ public class AllureSampleRegistryGenerator : IIncrementalGenerator
     static void AppendRegistryEntryProperty(
         StringBuilder sb,
         string registryNamespace,
-        SampleRegistryEntry entry
+        RegistryEntry entry
     )
     {
         var sampleName = entry.SampleName;

--- a/build/Allure.Build.SourceGenerators/Samples/RegistryEntry.cs
+++ b/build/Allure.Build.SourceGenerators/Samples/RegistryEntry.cs
@@ -1,6 +1,6 @@
-namespace Allure.Build.SourceGenerators;
+namespace Allure.Build.SourceGenerators.Samples;
 
-public record class SampleRegistryEntry(
+sealed record class RegistryEntry(
     string RegistryNamespace,
     string SampleName,
     string SourcePath,

--- a/build/Allure.Build.SourceGenerators/Samples/RegistrySource.cs
+++ b/build/Allure.Build.SourceGenerators/Samples/RegistrySource.cs
@@ -1,0 +1,5 @@
+using System.Collections.Immutable;
+
+namespace Allure.Build.SourceGenerators.Samples;
+
+sealed record RegistrySource(string Namespace, ImmutableArray<RegistryEntry> Entries);

--- a/build/Allure.Build.SourceGenerators/Samples/RegistrySourceComparer.cs
+++ b/build/Allure.Build.SourceGenerators/Samples/RegistrySourceComparer.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Allure.Build.SourceGenerators.Samples;
+
+sealed class RegistrySourceComparer : IEqualityComparer<RegistrySource>
+{
+    public bool Equals(RegistrySource x, RegistrySource y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return true;
+        }
+
+        if (x is null || y is null)
+        {
+            return false;
+        }
+
+        return x.Namespace == y.Namespace && x.Entries.SequenceEqual(y.Entries);
+    }
+
+    public int GetHashCode(RegistrySource obj)
+    {
+        unchecked
+        {
+            int hash = 17;
+
+            var @namespace = obj.Namespace;
+            hash = hash * 31 + (@namespace?.GetHashCode() ?? 0);
+
+            foreach (var entry in obj.Entries)
+            {
+                hash = hash * 31 + (entry?.GetHashCode() ?? 0);
+            }
+
+            return hash;
+        }
+    }
+
+    public static RegistrySourceComparer Instance { get; } = new();
+}

--- a/build/Allure.Build.Tasks/Functions/Files.cs
+++ b/build/Allure.Build.Tasks/Functions/Files.cs
@@ -23,10 +23,10 @@ public static class Files
             destinationPath: Path.Combine(solutionDir, "nuget.config")
         );
 
-    public static GeneratedFileSource GlobalsJson(string solutionDir) =>
+    public static GeneratedFileSource GlobalJson(string solutionDir) =>
         GeneratedFileSource.FromJsonSourceObject(
             sourceValue: new { test = new { runner = "Microsoft.Testing.Platform" } },
-            destinationPath: Path.Combine(solutionDir, "globals.json")
+            destinationPath: Path.Combine(solutionDir, "global.json")
         );
 
     public static GeneratedFileSource Solution(

--- a/build/Allure.Build.Tasks/Functions/Files.cs
+++ b/build/Allure.Build.Tasks/Functions/Files.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
+using Allure.Build.Tasks.Sources;
 
 namespace Allure.Build.Tasks.Functions;
 
@@ -20,6 +21,12 @@ public static class Files
         GeneratedFileSource.FromXmlDocument(
             document: XmlDefinitions.NugetConfig(localRepository, cacheLocation),
             destinationPath: Path.Combine(solutionDir, "nuget.config")
+        );
+
+    public static GeneratedFileSource GlobalsJson(string solutionDir) =>
+        GeneratedFileSource.FromJsonSourceObject(
+            sourceValue: new { test = new { runner = "Microsoft.Testing.Platform" } },
+            destinationPath: Path.Combine(solutionDir, "globals.json")
         );
 
     public static GeneratedFileSource Solution(

--- a/build/Allure.Build.Tasks/Functions/Files.cs
+++ b/build/Allure.Build.Tasks/Functions/Files.cs
@@ -52,6 +52,7 @@ public static class Files
     public static GeneratedFileSource DirectoryBuildProps(
         string solutionDir,
         string targetFrameworks,
+        string outputType,
         IEnumerable<string> imports,
         IEnumerable<string> packages,
         IEnumerable<string> projects,
@@ -59,11 +60,12 @@ public static class Files
     ) =>
         GeneratedFileSource.FromXmlDocument(
             document: XmlDefinitions.DirectoryBuildProps(
-                imports,
-                targetFrameworks,
-                packages,
-                projects,
-                analyzerProjects
+                imports: imports,
+                targetFrameworks: targetFrameworks,
+                outputType: outputType,
+                packages: packages,
+                projects: projects,
+                analyzerProjects: analyzerProjects
             ),
             destinationPath: Path.Combine(solutionDir, "Directory.Build.props"),
             omitDeclaration: true

--- a/build/Allure.Build.Tasks/Functions/Logging.cs
+++ b/build/Allure.Build.Tasks/Functions/Logging.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
+using Allure.Build.Tasks.Sources;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 

--- a/build/Allure.Build.Tasks/Functions/Logging.cs
+++ b/build/Allure.Build.Tasks/Functions/Logging.cs
@@ -152,7 +152,7 @@ public static class Logging
                   """,
             sample.ItemSpec,
             sampleName,
-            // Keep escapint to display a value that is ready for copy and paste
+            // Keep escaping to display a value that is ready for copy and paste
             // to the test project file.
             Path.GetRelativePath(projectDirectory, sample.EvaluatedIncludeEscaped)
         );

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -34,6 +34,15 @@ public static class Projects
                 .Where(static (csproj) => csproj is not null)
         ];
 
+    public static string ResolveOutputType(string testingPlatform) => testingPlatform switch
+    {
+        null or "" or "VsTest" => "Library",
+        "MicrosoftTestingPlatform" => "Exe",
+        var value => throw new ArgumentException(
+            $"The testing platform '{value}' is not supported"
+        ),
+    };
+
     static AllureSample ToAllureSample(
         TaskLoggingHelper log,
         string testProjectDirectory,

--- a/build/Allure.Build.Tasks/Functions/Projects.cs
+++ b/build/Allure.Build.Tasks/Functions/Projects.cs
@@ -4,6 +4,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
+using Allure.Build.Tasks.Sources;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Microsoft.CodeAnalysis.CSharp;

--- a/build/Allure.Build.Tasks/Functions/XmlDefinitions.cs
+++ b/build/Allure.Build.Tasks/Functions/XmlDefinitions.cs
@@ -105,6 +105,7 @@ public static class XmlDefinitions
     public static XDocument DirectoryBuildProps(
         IEnumerable<string> imports,
         string targetFrameworks,
+        string outputType,
         IEnumerable<string> packages,
         IEnumerable<string> projects,
         IEnumerable<string> analyzerProjects
@@ -116,7 +117,7 @@ public static class XmlDefinitions
                 ..imports.Select(MsBuild.GetImport),
                 MsBuild.GetPropertyGroup([
                     ("TargetFrameworks", targetFrameworks),
-                    ("OutputType", "Library"),
+                    ("OutputType", outputType),
                     ("EnableDefaultItems", "false"),
                     ("IsTestProject", "true"),
                     ("AspectInjector_Enabled", "false")

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -99,7 +99,7 @@ public class GenerateSampleSolution : Task
         if (this.TestingPlatform is "MicrosoftTestingPlatform")
         {
             sampleSolutionFiles = sampleSolutionFiles.Prepend(
-                Files.GlobalsJson(this.SampleSolutionDir)
+                Files.GlobalJson(this.SampleSolutionDir)
             );
         }
 

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -28,6 +28,9 @@ public class GenerateSampleSolution : Task
     public string RootNamespace { get; set; }
 
     [Required]
+    public string TestingPlatform { get; set; }
+
+    [Required]
     public string SampleSolutionDir { get; set; }
 
     [Required]
@@ -111,6 +114,7 @@ public class GenerateSampleSolution : Task
         Files.DirectoryBuildProps(
             solutionDir: this.SampleSolutionDir,
             targetFrameworks: this.SampleTargetFrameworks,
+            outputType: Projects.ResolveOutputType(this.TestingPlatform),
             imports.PropsFiles,
             packages: this.CommonPackageNames,
             projects: this.SampleProjectReferences.Select((item) =>

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using Allure.Build.Tasks.DataTypes;
 using Allure.Build.Tasks.Functions;
+using Allure.Build.Tasks.Sources;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -85,7 +86,7 @@ public class GenerateSampleSolution : Task
         var projectFiles = this.PrepareProjects();
         var slnx = this.PrepareSolutionFile(projectFiles);
 
-        FileProcessor.CommitSampleFiles(this.Log, this.SampleSolutionDir, [
+        IEnumerable<FileSource> sampleSolutionFiles = [
             slnx,
             directorySolutionTargets,
             directoryBuildProps,
@@ -93,7 +94,16 @@ public class GenerateSampleSolution : Task
             directoryPackagesProps,
             nugetConfig,
             ..projectFiles,
-        ]);
+        ];
+
+        if (this.TestingPlatform is "MicrosoftTestingPlatform")
+        {
+            sampleSolutionFiles = sampleSolutionFiles.Prepend(
+                Files.GlobalsJson(this.SampleSolutionDir)
+            );
+        }
+
+        FileProcessor.CommitSampleFiles(this.Log, this.SampleSolutionDir, sampleSolutionFiles);
 
         return true;
     }

--- a/build/Allure.Build.Tasks/GenerateSampleSolution.cs
+++ b/build/Allure.Build.Tasks/GenerateSampleSolution.cs
@@ -144,7 +144,7 @@ public class GenerateSampleSolution : Task
                     // Keep escape as we're writing these values to Directory.Package.props
                     // and the project file as is.
                     name: item.EvaluatedIncludeEscaped,
-                    varsion: item.GetMetadataValueEscaped("Version")
+                    version: item.GetMetadataValueEscaped("Version")
                 )
             )
         );

--- a/build/Allure.Build.Tasks/Sources/GeneratedFileSource.cs
+++ b/build/Allure.Build.Tasks/Sources/GeneratedFileSource.cs
@@ -1,11 +1,11 @@
 using System.IO;
+using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
 using Allure.Build.Tasks.Functions;
-using Allure.Build.Tasks.Sources;
 using Microsoft.Build.Utilities;
 
-namespace Allure.Build.Tasks;
+namespace Allure.Build.Tasks.Sources;
 
 public class GeneratedFileSource(byte[] content, string destinationPath): FileSource(destinationPath)
 {
@@ -72,5 +72,24 @@ public class GeneratedFileSource(byte[] content, string destinationPath): FileSo
         writer.Flush();
         stream.Position = 0;
         return new(stream.ToArray(), destinationPath);
+    }
+
+    public static GeneratedFileSource FromJsonSourceObject<T>(T sourceValue, string destinationPath) =>
+        FromJsonSourceObject(sourceValue, new()
+        {
+            WriteIndented = true,
+            IndentSize = 2,
+            IndentCharacter = ' ',
+        }, destinationPath);
+
+    public static GeneratedFileSource FromJsonSourceObject<T>(
+        T sourceValue,
+        JsonSerializerOptions options,
+        string destinationPath
+    )
+    {
+        using MemoryStream stream = new();
+        JsonSerializer.Serialize(stream, sourceValue, options);
+        return new (stream.ToArray(), destinationPath);
     }
 }

--- a/tests/Allure.NUnit.Tests/AllureIds/AllureIdTests.cs
+++ b/tests/Allure.NUnit.Tests/AllureIds/AllureIdTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.AllureIds;
 

--- a/tests/Allure.NUnit.Tests/BddLabels/BddLabelTests.cs
+++ b/tests/Allure.NUnit.Tests/BddLabels/BddLabelTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.BddLabels;
 

--- a/tests/Allure.NUnit.Tests/CustomLabels/CustomLabelTests.cs
+++ b/tests/Allure.NUnit.Tests/CustomLabels/CustomLabelTests.cs
@@ -1,4 +1,5 @@
 ﻿using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.CustomLabels;
 

--- a/tests/Allure.NUnit.Tests/Descriptions/DescriptionTests.cs
+++ b/tests/Allure.NUnit.Tests/Descriptions/DescriptionTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.Descriptions;
 

--- a/tests/Allure.NUnit.Tests/Names/NameTests.cs
+++ b/tests/Allure.NUnit.Tests/Names/NameTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.Names;
 

--- a/tests/Allure.NUnit.Tests/Owners/OwnerTests.cs
+++ b/tests/Allure.NUnit.Tests/Owners/OwnerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.Owners;
 

--- a/tests/Allure.NUnit.Tests/Parameters/ParameterTests.cs
+++ b/tests/Allure.NUnit.Tests/Parameters/ParameterTests.cs
@@ -1,5 +1,6 @@
 using Allure.Testing;
 using Allure.Testing.Assertions.Model;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.Parameters;
 

--- a/tests/Allure.NUnit.Tests/Severities/SeverityTests.cs
+++ b/tests/Allure.NUnit.Tests/Severities/SeverityTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.Severities;
 

--- a/tests/Allure.NUnit.Tests/SuiteLabels/SuiteLabelTests.cs
+++ b/tests/Allure.NUnit.Tests/SuiteLabels/SuiteLabelTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.NUnit.Tests.SuiteLabels;
 

--- a/tests/Allure.Testing/AllureSampleRunner.cs
+++ b/tests/Allure.Testing/AllureSampleRunner.cs
@@ -213,7 +213,7 @@ public class AllureSampleRunner
     ) => new(
         "dotnet",
         [
-            "test",
+            ..ResolveTestingPlatformSpecificArguments(sample.TestingPlatform),
             sample.ProjectFilePath,
             "--framework",
             sample.TargetFramework,
@@ -230,6 +230,16 @@ public class AllureSampleRunner
         StandardOutputEncoding = encoding,
         UseShellExecute = false,
     };
+
+    static IEnumerable<string> ResolveTestingPlatformSpecificArguments(TestingPlatform testingPlatform) =>
+        testingPlatform switch
+        {
+            TestingPlatform.VsTest => ["test"],
+            TestingPlatform.MicrosoftTestingPlatform => ["run", "--project"],
+            var value => throw new InvalidOperationException(
+                $"Unknown testing platform '{value}'"
+            ),
+        };
 
     static void ApplyExtraEnvironmentVariables(
         IEnumerable<KeyValuePair<string, string>> envVars,

--- a/tests/Allure.Testing/AllureSampleRunner.cs
+++ b/tests/Allure.Testing/AllureSampleRunner.cs
@@ -148,7 +148,7 @@ public class AllureSampleRunner
         // Make sure the process tree is stopped if an exception occurs.
         using var processGuard = Guard.WrapProcess(process);
 
-        var stdStreamsTask = SetProcessStreamCollection(process, ct);
+        var stdStreamsTask = CollectProcessOutput(process, ct);
 
         await WaitForExit(process, input.Timeout, ct);
 
@@ -321,13 +321,17 @@ public class AllureSampleRunner
         return Guard.WrapDirectory(resultsDir, own: useTempDir);
     }
 
-    static async Task<(string, string)> SetProcessStreamCollection(
+    static async Task<(string, string)> CollectProcessOutput(
         Process process,
         CancellationToken ct
-    ) => (
-        await CollectProcessStream(process.StandardOutput, ct),
-        await CollectProcessStream(process.StandardError, ct)
-    );
+    )
+    {
+        var streams = await Task.WhenAll(
+            CollectProcessStream(process.StandardOutput, ct),
+            CollectProcessStream(process.StandardError, ct)
+        );
+        return (streams[0], streams[1]);
+    }
 
     static async Task WaitForExit(Process process, TimeSpan timeout, CancellationToken ct)
     {

--- a/tests/Allure.Testing/AllureSampleRunner.cs
+++ b/tests/Allure.Testing/AllureSampleRunner.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Allure.Testing.Assertions.Model;
+using Allure.Testing.Execution;
 using Allure.Testing.Internal;
 using TUnit.Assertions.Core;
 using TUnit.Assertions.Exceptions;

--- a/tests/Allure.Testing/AllureSampleRunner.cs
+++ b/tests/Allure.Testing/AllureSampleRunner.cs
@@ -232,7 +232,7 @@ public class AllureSampleRunner
             StandardOutputEncoding = encoding,
             UseShellExecute = false,
         };
-        psi.Environment.Add("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+        psi.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
         return psi;
     }
 

--- a/tests/Allure.Testing/AllureSampleRunner.cs
+++ b/tests/Allure.Testing/AllureSampleRunner.cs
@@ -210,26 +210,31 @@ public class AllureSampleRunner
     static ProcessStartInfo CreateProcessStartInfo(
         AllureSampleRegistryEntry sample,
         IEnumerable<string> args
-    ) => new(
-        "dotnet",
-        [
-            ..ResolveTestingPlatformSpecificArguments(sample.TestingPlatform),
-            sample.ProjectFilePath,
-            "--framework",
-            sample.TargetFramework,
-            "--configuration",
-            sample.BuildConfiguration,
-            ..args,
-        ]
     )
     {
-        CreateNoWindow = true,
-        RedirectStandardError = true,
-        RedirectStandardOutput = true,
-        StandardErrorEncoding = encoding,
-        StandardOutputEncoding = encoding,
-        UseShellExecute = false,
-    };
+        ProcessStartInfo psi = new(
+            "dotnet",
+            [
+                ..ResolveTestingPlatformSpecificArguments(sample.TestingPlatform),
+                sample.ProjectFilePath,
+                "--framework",
+                sample.TargetFramework,
+                "--configuration",
+                sample.BuildConfiguration,
+                ..args,
+            ]
+        )
+        {
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            StandardErrorEncoding = encoding,
+            StandardOutputEncoding = encoding,
+            UseShellExecute = false,
+        };
+        psi.Environment.Add("DOTNET_CLI_TELEMETRY_OPTOUT", "1");
+        return psi;
+    }
 
     static IEnumerable<string> ResolveTestingPlatformSpecificArguments(TestingPlatform testingPlatform) =>
         testingPlatform switch

--- a/tests/Allure.Testing/Execution/AllureSampleRegistryEntry.cs
+++ b/tests/Allure.Testing/Execution/AllureSampleRegistryEntry.cs
@@ -1,4 +1,4 @@
-namespace Allure.Testing;
+namespace Allure.Testing.Execution;
 
 /// <summary>
 /// Contains the data required to run a specific sample project and access its output.

--- a/tests/Allure.Testing/Execution/AllureSampleRegistryEntry.cs
+++ b/tests/Allure.Testing/Execution/AllureSampleRegistryEntry.cs
@@ -7,6 +7,9 @@ namespace Allure.Testing.Execution;
 /// Instances are typically created and populated by the testing infrastructure. Use the
 /// auto-generated <c>AllureSampleRegistry</c> class to access them.
 /// </remarks>
+/// <param name="TestingPlatform">
+/// Defines which testing platform, VSTest or MTP, the runner should use to execute the samples.
+/// </param>
 /// <param name="RegistryId">
 /// The ID of the registry that contains the sample, typically its namespace.
 /// This value is only used for diagnostics.
@@ -32,6 +35,7 @@ namespace Allure.Testing.Execution;
 /// These results are typically prepared by <c>dotnet msbuild -t:Allure_RunTestSamples</c>.
 /// </param>
 public record struct AllureSampleRegistryEntry(
+    TestingPlatform TestingPlatform,
     string RegistryId,
     string SampleId,
     string ProjectFilePath,

--- a/tests/Allure.Testing/Execution/AllureSampleRunInput.cs
+++ b/tests/Allure.Testing/Execution/AllureSampleRunInput.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Allure.Testing;
+namespace Allure.Testing.Execution;
 
 /// <summary>
 /// Contains data that affects the execution of the sample project.

--- a/tests/Allure.Testing/Execution/AllureSampleRunInput.cs
+++ b/tests/Allure.Testing/Execution/AllureSampleRunInput.cs
@@ -15,9 +15,14 @@ public record class AllureSampleRunInput
     public object? AllureConfiguration { get; init; } = null;
 
     /// <summary>
-    /// The path to a directory used to write results Allure results to and read them from.
+    /// The path to a directory used to write Allure results to and read them from.
     /// An absolute path is recommended.
     /// </summary>
+    /// <remarks>
+    /// When this value is set, the directory is caller-owned: the runner does not
+    /// create, clear, or delete it. Existing files may be included in the returned
+    /// results.
+    /// </remarks>
     public string? AllureResultsDirectory { get; init; } = null;
 
     /// <summary>

--- a/tests/Allure.Testing/Execution/TestingPlatform.cs
+++ b/tests/Allure.Testing/Execution/TestingPlatform.cs
@@ -1,0 +1,19 @@
+namespace Allure.Testing.Execution;
+
+/// <summary>
+/// Identifies the testing platform used to execute a test sample project.
+/// </summary>
+public enum TestingPlatform
+{
+    /// <summary>
+    /// Executes the test sample project through the VSTest platform,
+    /// such as via the VSTest-based <c>dotnet test</c> flow.
+    /// </summary>
+    VsTest,
+
+    /// <summary>
+    /// Executes the test sample project through Microsoft Testing Platform,
+    /// i.e., via the MTP-based <c>dotnet run</c> flow.
+    /// </summary>
+    MicrosoftTestingPlatform,
+}

--- a/tests/Allure.Testing/Internal/Guard.cs
+++ b/tests/Allure.Testing/Internal/Guard.cs
@@ -30,7 +30,7 @@ internal class Guard<T>(T value, Action<T> dispose, bool own = true) : IDisposab
             if (!this.Own)
             {
                 throw new InvalidOperationException(
-                    "Can't transfer: the guard don't own the resourse"
+                    "Can't transfer: the guard doesn't own the resourse"
                 );
             }
 

--- a/tests/Allure.Testing/Internal/Guard.cs
+++ b/tests/Allure.Testing/Internal/Guard.cs
@@ -30,7 +30,7 @@ internal class Guard<T>(T value, Action<T> dispose, bool own = true) : IDisposab
             if (!this.Own)
             {
                 throw new InvalidOperationException(
-                    "Can't transfer: the guard doesn't own the resourse"
+                    "Can't transfer: the guard doesn't own the resource"
                 );
             }
 

--- a/tests/Allure.Xunit.Tests/AllureIds/AllureIdTests.cs
+++ b/tests/Allure.Xunit.Tests/AllureIds/AllureIdTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.Xunit.Tests.AllureIds;
 

--- a/tests/Allure.Xunit.Tests/BddLabels/BddLabelTests.cs
+++ b/tests/Allure.Xunit.Tests/BddLabels/BddLabelTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.Xunit.Tests.BddLabels;
 

--- a/tests/Allure.Xunit.Tests/Names/NameTests.cs
+++ b/tests/Allure.Xunit.Tests/Names/NameTests.cs
@@ -1,4 +1,5 @@
 using Allure.Testing;
+using Allure.Testing.Execution;
 
 namespace Allure.Xunit.Tests.Names;
 

--- a/tests/Allure.Xunit.Tests/Parameters/ParameterTests.cs
+++ b/tests/Allure.Xunit.Tests/Parameters/ParameterTests.cs
@@ -1,5 +1,6 @@
 using Allure.Testing;
 using Allure.Testing.Assertions.Model;
+using Allure.Testing.Execution;
 
 namespace Allure.Xunit.Tests.Parameters;
 

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -120,7 +120,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- We're only including .cs samples by default. Other files needs to be included on a
+        <!-- We're only including .cs samples by default. Other files need to be included on a
          per-project basis.
         Each AllureSample becomes an item in the generated sample project. The item includes
          the original sample file. You can control the item type by applying ItemType="...".

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -3,6 +3,10 @@
             Condition="'' != $([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
     <PropertyGroup>
+        <Allure_TestingPlatform Condition=" '$(Allure_TestingPlatform)' == '' ">VsTest</Allure_TestingPlatform>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <!-- Don't compile samples as part of test projects. -->
         <DefaultItemExcludes>$(DefaultItemExcludes);@(AllureSample)</DefaultItemExcludes>
 
@@ -82,6 +86,7 @@
     <PropertyGroup>
         <!-- The list of Allure properties used by the sample runner. -->
         <Allure_CompilerVisibleProperties>
+            Allure_TestingPlatform;
             Allure_PreRunTestingFlow;
             Allure_SampleConfiguration;
             Allure_SampleSolutionDir;

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -163,7 +163,7 @@
 
         <Exec
             Condition=" '$(Allure_TestTargetVersion)' != '' "
-            Command="dotnet msbuild -getProperty:PackageId '%(ProjectUnderTest.Identity)'"
+            Command="dotnet msbuild -getProperty:PackageId &quot;%(ProjectUnderTest.Identity)&quot;"
             ConsoleToMsBuild="true"
             StandardOutputImportance="low">
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -201,6 +201,7 @@
             SampleProjectReferences="@(SampleProjectReference)"
             ProjectDirectory="$(MSBuildProjectDirectory)"
             RootNamespace="$(RootNamespace)"
+            TestingPlatform="$(Allure_TestingPlatform)"
             SampleSolutionDir="$(Allure_SampleSolutionDir)"
             SampleSolutionName="$(Allure_SampleSolutionName)"
             SampleSolutionPath="$(_Allure_SampleSolutionPath)"

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -40,16 +40,18 @@
         )</_Allure_ObjDirectory>
     </PropertyGroup>
 
-    <!-- Normalize casing-->
+    <!-- Normalize casing, set the test MSBuild target -->
     <Choose>
         <When Condition=" '$(Allure_TestingPlatform)' == 'VsTest' ">
             <PropertyGroup>
                 <Allure_TestingPlatform>VsTest</Allure_TestingPlatform>
+                <_Allure_TestSampleTarget>VSTest</_Allure_TestSampleTarget>
             </PropertyGroup>
         </When>
         <When Condition=" '$(Allure_TestingPlatform)' == 'MicrosoftTestingPlatform' ">
             <PropertyGroup>
                 <Allure_TestingPlatform>MicrosoftTestingPlatform</Allure_TestingPlatform>
+                <_Allure_TestSampleTarget>Run</_Allure_TestSampleTarget>
             </PropertyGroup>
         </When>
         <Otherwise>
@@ -301,7 +303,7 @@
             Targets="Allure_RunTestSamples"
             BuildInParallel="$(BuildInParallel)"
             Properties="
-                Allure_TestSampleTarget=VSTest;
+                Allure_TestSampleTarget=$(_Allure_TestSampleTarget);
                 Configuration=$(Allure_SampleConfiguration);
                 Allure_BuildInParallel=$(BuildInParallel);
             "

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -9,15 +9,23 @@
                 '..',
             )
         )</_Allure_RepoRoot>
-        <_Allure_BuildTaskPath>$(
+        <_Allure_BuildTaskProjectName>Allure.Build.Tasks</_Allure_BuildTaskProjectName>
+        <_Allure_BuildTaskProjectDir>$(
+            [MSBuild]::NormalizeDirectory(
+                '$(_Allure_RepoRoot)',
+                'build',
+                '$(_Allure_BuildTaskProjectName)'
+            )
+        )</_Allure_BuildTaskProjectDir>
+        <_Allure_BuildTaskAssemblyPath>$(
             [MSBuild]::NormalizePath(
                 '$(ArtifactsPath)',
                 'bin',
-                'Allure.Build.Tasks',
+                '$(_Allure_BuildTaskProjectName)',
                 'release',
-                'Allure.Build.Tasks.dll'
+                '$(_Allure_BuildTaskProjectName).dll'
             )
-        )</_Allure_BuildTaskPath>
+        )</_Allure_BuildTaskAssemblyPath>
         <_Allure_BinDirectory>$(
             [MSBuild]::NormalizePath(
                 '$(ArtifactsPath)',
@@ -34,15 +42,15 @@
 
     <UsingTask
         TaskName="Allure.Build.Tasks.GenerateSampleSolution"
-        AssemblyFile="$(_Allure_BuildTaskPath)"/>
+        AssemblyFile="$(_Allure_BuildTaskAssemblyPath)"/>
 
     <UsingTask
         TaskName="Allure.Build.Tasks.FillSampleMetadata"
-        AssemblyFile="$(_Allure_BuildTaskPath)"/>
+        AssemblyFile="$(_Allure_BuildTaskAssemblyPath)"/>
 
     <UsingTask
         TaskName="Allure.Build.Tasks.ResolveRegistryEntries"
-        AssemblyFile="$(_Allure_BuildTaskPath)"/>
+        AssemblyFile="$(_Allure_BuildTaskAssemblyPath)"/>
 
     <PropertyGroup>
 
@@ -64,15 +72,28 @@
         <DefineConstants>$(DefineConstants);ALLURE_TEST_PRERUN_FLOW</DefineConstants>
     </PropertyGroup>
 
-    <Target Name="_Allure_CompileBuildTasks">
+    <ItemGroup>
+        <_Allure_CompileBuildTasksInput Include="$(_Allure_BuildTaskProjectDir)**/*" />
+        <_Allure_CompileBuildTasksInput Include="$([MSBuild]::NormalizePath(
+            '$(_Allure_RepoRoot)',
+            'Directory.Build.props'
+        ))" />
+        <_Allure_CompileBuildTasksInput Include="$([MSBuild]::NormalizePath(
+            '$(_Allure_RepoRoot)',
+            'Directory.Build.targets'
+        ))" />
+    </ItemGroup>
+
+    <Target
+        Name="_Allure_CompileBuildTasks"
+        Inputs="@(_Allure_CompileBuildTasksInput)"
+        Outputs="$(_Allure_BuildTaskAssemblyPath)">
 
         <PropertyGroup>
             <_Allure_BuildTasksProject>$(
                 [MSBuild]::NormalizePath(
-                    '$(_Allure_RepoRoot)',
-                    'build',
-                    'Allure.Build.Tasks',
-                    'Allure.Build.Tasks.csproj'
+                    '$(_Allure_BuildTaskProjectDir)',
+                    '$(_Allure_BuildTaskProjectName).csproj'
                 )
             )</_Allure_BuildTasksProject>
         </PropertyGroup>

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -40,6 +40,25 @@
         )</_Allure_ObjDirectory>
     </PropertyGroup>
 
+    <!-- Normalize casing-->
+    <Choose>
+        <When Condition=" '$(Allure_TestingPlatform)' == 'VsTest' ">
+            <PropertyGroup>
+                <Allure_TestingPlatform>VsTest</Allure_TestingPlatform>
+            </PropertyGroup>
+        </When>
+        <When Condition=" '$(Allure_TestingPlatform)' == 'MicrosoftTestingPlatform' ">
+            <PropertyGroup>
+                <Allure_TestingPlatform>VsTest</Allure_TestingPlatform>
+            </PropertyGroup>
+        </When>
+        <Otherwise>
+            <PropertyGroup>
+                <_Allure_Error>Unknown testing platform '$(Allure_TestingPlatform)'. Please, set the 'Allure_TestingPlatform' property to 'VsTest' or 'MicrosoftTestingPlatform'</_Allure_Error>
+            </PropertyGroup>
+        </Otherwise>
+    </Choose>
+
     <UsingTask
         TaskName="Allure.Build.Tasks.GenerateSampleSolution"
         AssemblyFile="$(_Allure_BuildTaskAssemblyPath)"/>
@@ -83,6 +102,10 @@
             'Directory.Build.targets'
         ))" />
     </ItemGroup>
+
+    <Target Name="Allure_FailIfError" Condition=" '$(_Allure_Error)' != '' ">
+        <Error Text="$(_Allure_Error)" />
+    </Target>
 
     <Target
         Name="_Allure_CompileBuildTasks"
@@ -146,7 +169,7 @@
     <Target Name="_Allure_InjectSamplesToSourceGenerator"
             BeforeTargets="GenerateMSBuildEditorConfigFileShouldRun"
             Condition=" '@(AllureSample)' != '' "
-            DependsOnTargets="_Allure_ResolveSampleRegistryEntries">
+            DependsOnTargets="Allure_FailIfError;_Allure_ResolveSampleRegistryEntries">
 
         <!-- At this point, all AllureSample items must already be defined,
          the required properties resolved (see FillSampleMetadata) and the corresponding
@@ -172,7 +195,8 @@
      See https://github.com/dotnet/msbuild/pull/3978. -->
     <Target Name="_Allure_ResolveTestTarget"
             BeforeTargets="ResolveAssemblyReferences"
-            Condition=" '@(AllureSample)' != '' ">
+            Condition=" '@(AllureSample)' != '' "
+            DependsOnTargets="Allure_FailIfError">
 
         <PropertyGroup Condition=" '$(Allure_TestTargetVersion)' == 'SNAPSHOT' ">
             <Allure_TestTargetVersion>$(Version)</Allure_TestTargetVersion>
@@ -212,7 +236,7 @@
     <Target Name="Allure_GenerateTestSamples"
             AfterTargets="CopyFilesToOutputDirectory"
             Condition=" '@(AllureSample)' != '' "
-            DependsOnTargets="_Allure_CompileBuildTasks;_Allure_ResolveTestTarget;_Allure_ResolveTestSamples">
+            DependsOnTargets="Allure_FailIfError;_Allure_CompileBuildTasks;_Allure_ResolveTestTarget;_Allure_ResolveTestSamples">
 
         <MakeDir Directories="$(Allure_LocalNugetRepository)" />
 
@@ -242,7 +266,8 @@
     </Target>
 
     <Target Name="Allure_BuildTestSamples"
-            Condition=" '@(AllureSample)' != '' ">
+            Condition=" '@(AllureSample)' != '' "
+            DependsOnTargets="Allure_FailIfError">
 
         <MSBuild
             Projects="$(_Allure_SampleSolutionPath)"
@@ -255,7 +280,7 @@
 
     <Target Name="Allure_RunTestSamples"
             Condition=" '@(AllureSample)' != '' "
-            DependsOnTargets="_Allure_ResolveTestSamples">
+            DependsOnTargets="Allure_FailIfError;_Allure_ResolveTestSamples">
 
         <Error Text="The sample solution $(_Allure_SampleSolutionPath) doesn't exist. Build $(MSBuildProjectName) to generate it"
             Condition=" !Exists('$(_Allure_SampleSolutionPath)') " />

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -49,7 +49,7 @@
         </When>
         <When Condition=" '$(Allure_TestingPlatform)' == 'MicrosoftTestingPlatform' ">
             <PropertyGroup>
-                <Allure_TestingPlatform>VsTest</Allure_TestingPlatform>
+                <Allure_TestingPlatform>MicrosoftTestingPlatform</Allure_TestingPlatform>
             </PropertyGroup>
         </When>
         <Otherwise>


### PR DESCRIPTION
### Context

The PR introduces a new `Allure_TestingPlatform` MSBuild property for test projects. It takes one of two values:

  - `VsTest` (the default): set `OutputType` of the sample projects to `Library` and use `dotnet test` to execute them.
  - `MicrosoftTestingPlatform`: set `OutputType` of the sample projects to `Exe` and use `dotnet run` to execute them.

Projects with integration tests for MTP-based adapters (like Xunit.v3) should add the following to `.csproj`:

```xml
<PropertyGroup>
    <Allure_TestingPlatform>MicrosoftTestingPlatform</Allure_TestingPlatform>
</PropertyGroup>
```

Projects that test non-MTP integrations may omit the property and use `VSTest` by default.

Samples can be run with `dotnet test` regardless of the platform, but for MTP, `global.json` that sets the test runner to `Microsoft.Testing.Platform` must exist in the current directory. Currently, we still have VSTest tests, so you need to switch to the sample solution directory and then run `dotnet test`. As soon as we move all existing tests to MTP, that won'te be necessary.

### Other fixes

The PR also fixes a bunch of test-related issues:

  - A potential stdout/stderr deadlock in `AllureSampleRunner`.
  - Improper quoting when resolving the test package version.
  - `_Allure_CompileBuildTasks` runs the Allure.Build.Tasks compilation even if no source file changed.
  - `AllureSampleRegistryGenerator` regenerates all registries on each sample change, even those that were unchanged.
  - Some grammar errors in doc comments and error messages.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
