### PR TITLE
Set up configuration schema publishing

### DIFF
--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -1,0 +1,112 @@
+name: Publish schemas
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release version and matching Git tag.
+        required: true
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version and matching Git tag.
+        required: true
+        type: string
+
+concurrency:
+  group: publish-schemas
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      pages: write
+      id-token: write
+      contents: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Validate version
+        shell: bash
+        env:
+          SCHEMA_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$SCHEMA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
+            echo "::error::Invalid schema version: $SCHEMA_VERSION"
+            exit 1
+          fi
+
+      - name: Checkout release
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.version }}
+          fetch-depth: 1
+
+      - name: Checkout Pages working copy
+        uses: actions/checkout@v7
+        with:
+          path: ./artifacts/schema-site
+          fetch-depth: 1
+
+      - name: Prepare Pages branch
+        working-directory: ./artifacts/schema-site
+        shell: bash
+        run: |
+          if git fetch --depth=1 origin gh-pages; then
+            git switch --force-create gh-pages FETCH_HEAD
+          else
+            git switch --orphan gh-pages
+            git rm -rf --ignore-unmatch .
+          fi
+
+      - name: Setup .NET Core SDK
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Generate schemas
+        shell: bash
+        env:
+          SCHEMA_VERSION: ${{ inputs.version }}
+        run: dotnet msbuild allure-csharp.slnx -t:Allure_PrepareSchemas -p:Version="$SCHEMA_VERSION"
+
+      - name: Update Pages branch
+        working-directory: ./artifacts/schema-site
+        shell: bash
+        env:
+          SCHEMA_VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          git add --all
+          git status --short
+
+          if git diff --cached --quiet; then
+            echo "Nothing to commit. The schemas are already up to date."
+          else
+            git commit -m "Publish schemas for ${SCHEMA_VERSION}"
+            git push origin HEAD:gh-pages
+          fi
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: ./artifacts/schema-site
+
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,15 @@ jobs:
   publish:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: 'Setup .NET Core SDK'
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: |
             3.1.x
             6.0.x
+            10.0.x
 
       - name: 'Restore the packages'
         shell: pwsh
@@ -80,3 +81,16 @@ jobs:
           dotnet nuget push ".\artifacts\package\release\*.nupkg" `
             --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
             --source "https://api.nuget.org/v3/index.json"
+
+  publish-schemas:
+    name: Publish schemas
+    needs: publish
+
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
+    uses: ./.github/workflows/publish-schemas.yml
+    with:
+      version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,10 @@ jobs:
             --no-restore\
             --no-build\
             --configuration ${{ env.BUILD_CONFIGURATION }}
+          npx -y allure@3 run --config ./.allurerc.mjs --rerun 2 --environment="${{ env.BUILD_CONFIGURATION }}" --dump="allure-results-schemas" -- dotnet run --project ./tests/Allure.ConfigSchema.Tests\
+            --no-restore\
+            --no-build\
+            --configuration ${{ env.BUILD_CONFIGURATION }}
 
       - name: Generate Allure report
         env:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,4 +28,37 @@
         <SignAssembly>false</SignAssembly>
         <AssemblyOriginatorKeyFile>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', 'build', 'identity.snk'))</AssemblyOriginatorKeyFile>
     </PropertyGroup>
+
+    <PropertyGroup>
+        <_Allure_RepoRoot>$(MSBuildThisFileDirectory)</_Allure_RepoRoot>
+        <_Allure_BuildTaskProjectName>Allure.Build.Tasks</_Allure_BuildTaskProjectName>
+        <_Allure_BuildTaskProjectDir>$(
+            [MSBuild]::NormalizeDirectory(
+                '$(_Allure_RepoRoot)',
+                'build',
+                '$(_Allure_BuildTaskProjectName)'
+            )
+        )</_Allure_BuildTaskProjectDir>
+        <_Allure_BinDirectory>$(
+            [MSBuild]::NormalizePath(
+                '$(ArtifactsPath)',
+                'bin'
+            )
+        )</_Allure_BinDirectory>
+        <_Allure_BuildTaskAssemblyPath>$(
+            [MSBuild]::NormalizePath(
+                '$(_Allure_BinDirectory)',
+                '$(_Allure_BuildTaskProjectName)',
+                'release',
+                '$(_Allure_BuildTaskProjectName).dll'
+            )
+        )</_Allure_BuildTaskAssemblyPath>
+
+        <_Allure_ObjDirectory>$(
+            [MSBuild]::NormalizePath(
+                '$(ArtifactsPath)',
+                'obj'
+            )
+        )</_Allure_ObjDirectory>
+    </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,39 @@
 <Project>
+
+    <ItemGroup>
+        <_Allure_CompileBuildTasksInput Include="$(_Allure_BuildTaskProjectDir)**/*" />
+        <_Allure_CompileBuildTasksInput Include="$([MSBuild]::NormalizePath(
+            '$(_Allure_RepoRoot)',
+            'Directory.Build.props'
+        ))" />
+        <_Allure_CompileBuildTasksInput Include="$([MSBuild]::NormalizePath(
+            '$(_Allure_RepoRoot)',
+            'Directory.Build.targets'
+        ))" />
+    </ItemGroup>
+
+    <Target
+        Name="_Allure_CompileBuildTasks"
+        Inputs="@(_Allure_CompileBuildTasksInput)"
+        Outputs="$(_Allure_BuildTaskAssemblyPath)">
+
+        <PropertyGroup>
+            <_Allure_BuildTasksProject>$(
+                [MSBuild]::NormalizePath(
+                    '$(_Allure_BuildTaskProjectDir)',
+                    '$(_Allure_BuildTaskProjectName).csproj'
+                )
+            )</_Allure_BuildTasksProject>
+        </PropertyGroup>
+
+        <MSBuild
+            Projects="$(_Allure_BuildTasksProject)"
+            Targets="Restore;Build"
+            BuildInParallel="$(BuildInParallel)"
+            Properties="Configuration=Release" />
+
+    </Target>
+
     <!-- Some assemblies are strong-named.
      We need to re-sign them after AspectInjector runs and before publishing to NuGet.
      Otherwise, they will not pass the `sn.exe -vf <assembly>` check. -->
@@ -75,4 +110,6 @@
     <Target Name="Allure_RunTestSamples" />
     <Target Name="Allure_CleanTestSamples" />
     <Target Name="Allure_DeleteTestSamples" />
+    <Target Name="Allure_PrepareSchemas" />
+
 </Project>

--- a/allure-csharp.slnx
+++ b/allure-csharp.slnx
@@ -81,6 +81,9 @@
     </Project>
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Allure.ConfigSchema.Tests/Allure.ConfigSchema.Tests.csproj">
+      <Build Solution="Publish|*" Project="false" />
+    </Project>
     <Project Path="tests/Allure.Net.Commons.Tests/Allure.Net.Commons.Tests.csproj">
       <Build Solution="Publish|*" Project="false" />
     </Project>

--- a/build/Allure.Build.Tasks/PrepareConfigSchema.cs
+++ b/build/Allure.Build.Tasks/PrepareConfigSchema.cs
@@ -23,6 +23,12 @@ public class PrepareConfigSchema : Task
     [Required]
     public string PackageName { get; set; } = "";
 
+    [Output]
+    public string VersionedSchemaPath { get; set; } = "";
+
+    [Output]
+    public string LatestSchemaPath { get; set; } = "";
+
     public override bool Execute()
     {
         try
@@ -49,14 +55,14 @@ public class PrepareConfigSchema : Task
 
             RewriteReferences(versionedSchema, sourceId, schemaRoot, version);
 
-            Write(
+            this.LatestSchemaPath = Write(
                 latestSchema,
-                Path.Combine(this.OutputDirectory, packageName, fileName)
+                Path.Combine(this.OutputDirectory, "schemas", packageName, fileName)
             );
 
-            Write(
+            this.VersionedSchemaPath = Write(
                 versionedSchema,
-                Path.Combine(this.OutputDirectory, version, packageName, fileName)
+                Path.Combine(this.OutputDirectory, "schemas", version, packageName, fileName)
             );
 
             return true;
@@ -162,7 +168,7 @@ public class PrepareConfigSchema : Task
         }
     }
 
-    static void Write(JsonNode schema, string path)
+    static string Write(JsonNode schema, string path)
     {
         var source = GeneratedFileSource.FromJsonSourceObject(schema, path);
 
@@ -170,5 +176,7 @@ public class PrepareConfigSchema : Task
         {
             source.Write();
         }
+
+        return source.Destination.FullName;
     }
 }

--- a/build/Allure.Build.Tasks/PrepareConfigSchema.cs
+++ b/build/Allure.Build.Tasks/PrepareConfigSchema.cs
@@ -1,0 +1,174 @@
+using System;
+using System.IO;
+using System.Text.Json.Nodes;
+using Allure.Build.Tasks.Sources;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+#nullable enable
+
+namespace Allure.Build.Tasks;
+
+public class PrepareConfigSchema : Task
+{
+    [Required]
+    public string InputPath { get; set; } = "";
+
+    [Required]
+    public string OutputDirectory { get; set; } = "";
+
+    [Required]
+    public string Version { get; set; } = "";
+
+    [Required]
+    public string PackageName { get; set; } = "";
+
+    public override bool Execute()
+    {
+        try
+        {
+            var packageName = this.PackageName.ToLower();
+            var version = this.Version.ToLower();
+
+            var fileName = Path.GetFileName(this.InputPath);
+
+            var schema = JsonNode.Parse(
+                File.ReadAllBytes(this.InputPath)
+            ) as JsonObject
+                ?? throw new InvalidOperationException(
+                    $"Schema '{this.InputPath}' must contain a JSON object."
+                );
+
+            var sourceId = GetSchemaId(schema);
+            var schemaRoot = GetSchemaRoot(sourceId, packageName, fileName);
+
+            var latestSchema = schema.DeepClone();
+            var versionedSchema = schema.DeepClone();
+
+            versionedSchema["$id"] = AddVersion(sourceId, schemaRoot, version).AbsoluteUri;
+
+            RewriteReferences(versionedSchema, sourceId, schemaRoot, version);
+
+            Write(
+                latestSchema,
+                Path.Combine(this.OutputDirectory, packageName, fileName)
+            );
+
+            Write(
+                versionedSchema,
+                Path.Combine(this.OutputDirectory, version, packageName, fileName)
+            );
+
+            return true;
+        }
+        catch (Exception error)
+        {
+            this.Log.LogErrorFromException(error);
+            return false;
+        }
+    }
+
+    static Uri GetSchemaId(JsonObject schema)
+    {
+        var value = schema["$id"]?.GetValue<string>()
+            ?? throw new InvalidOperationException(
+                "The configuration schema must define a root '$id'."
+            );
+
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException(
+                $"Schema '$id' must be an absolute URI, but was '{value}'."
+            );
+        }
+
+        return uri;
+    }
+
+    static Uri GetSchemaRoot(Uri schemaId, string packageName, string fileName)
+    {
+        var expectedSuffix = $"/{packageName}/{fileName}";
+
+        if (!schemaId.AbsolutePath.EndsWith(expectedSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Schema '$id' must end with '{expectedSuffix}', "
+                    + $"but was '{schemaId}'."
+            );
+        }
+
+        return new(schemaId, "../");
+    }
+
+    static Uri AddVersion(Uri schemaId, Uri schemaRoot, string version)
+    {
+        var relative = schemaRoot.MakeRelativeUri(schemaId);
+        var versionPrefix = $"{Uri.EscapeDataString(version)}/";
+
+        return new(schemaRoot, versionPrefix + relative.OriginalString);
+    }
+
+    static void RewriteReferences(
+        JsonNode? node,
+        Uri sourceId,
+        Uri schemaRoot,
+        string version
+    )
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                if (obj["$ref"] is JsonValue referenceNode
+                    && referenceNode.TryGetValue<string>(out var reference)
+                    && !reference.StartsWith('#'))
+                {
+                    var resolved = new Uri(sourceId, reference);
+
+                    if (schemaRoot.IsBaseOf(resolved))
+                    {
+                        obj["$ref"] = AddVersion(
+                            resolved,
+                            schemaRoot,
+                            version
+                        ).AbsoluteUri;
+                    }
+                }
+
+                foreach (var property in obj)
+                {
+                    RewriteReferences(
+                        property.Value,
+                        sourceId,
+                        schemaRoot,
+                        version
+                    );
+                }
+
+                break;
+
+            case JsonArray array:
+
+                foreach (var item in array)
+                {
+                    RewriteReferences(
+                        item,
+                        sourceId,
+                        schemaRoot,
+                        version
+                    );
+                }
+
+                break;
+        }
+    }
+
+    static void Write(JsonNode schema, string path)
+    {
+        var source = GeneratedFileSource.FromJsonSourceObject(schema, path);
+
+        if (source.ShouldWrite)
+        {
+            source.Write();
+        }
+    }
+}

--- a/build/TransformReadmeForNuget.cs
+++ b/build/TransformReadmeForNuget.cs
@@ -1,6 +1,6 @@
 /*
  * The source code of the Allure_TransformReadmeForNuget task defined in Directory.Build.targets.
- * The task is used by the Allure_GenerateNugetReadmeFiles target. See Directory.Build.targets
+ * The task is used by the _Allure_GenerateNugetReadmeFile target. See Directory.Build.targets
  * for some details.
  *
 */

--- a/src/Allure.Net.Sdk/Configuration/JsonFileConfigurationSource.cs
+++ b/src/Allure.Net.Sdk/Configuration/JsonFileConfigurationSource.cs
@@ -269,7 +269,7 @@ public static class JsonFileConfigurationSource
         FromPathEnvironmentVariable<TConfiguration>("ALLURE_CONFIG");
 
     /// <summary>
-    /// Creates a source for <c>allure.config.json</c> in the application base directory.
+    /// Creates a source for <c>allureConfig.json</c> in the application base directory.
     /// </summary>
     /// <typeparam name="TConfiguration">The configuration type.</typeparam>
     /// <param name="isOptional">

--- a/src/Allure.Net.Sdk/Configuration/JsonFileConfigurationSource.cs
+++ b/src/Allure.Net.Sdk/Configuration/JsonFileConfigurationSource.cs
@@ -269,7 +269,7 @@ public static class JsonFileConfigurationSource
         FromPathEnvironmentVariable<TConfiguration>("ALLURE_CONFIG");
 
     /// <summary>
-    /// Creates a source for <c>allureConfig.json</c> in the application base directory.
+    /// Creates a source for <c>allure.config.json</c> in the application base directory.
     /// </summary>
     /// <typeparam name="TConfiguration">The configuration type.</typeparam>
     /// <param name="isOptional">
@@ -279,5 +279,22 @@ public static class JsonFileConfigurationSource
     public static JsonFileConfigurationSource<TConfiguration> FromBaseDirectory<TConfiguration>(bool isOptional)
         where TConfiguration : AllureConfiguration, new()
     =>
-        new(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "allureConfig.json"), isOptional);
+        FromBaseDirectory<TConfiguration>("allureConfig.json", isOptional);
+
+    /// <summary>
+    /// Creates a source for the configuration file in the application base directory.
+    /// </summary>
+    /// <typeparam name="TConfiguration">The configuration type.</typeparam>
+    /// <param name="fileName">The name of the configuration file.</param>
+    /// <param name="isOptional">
+    /// Whether the source should be skipped when the file does not exist.
+    /// </param>
+    /// <returns>The configuration source.</returns>
+    public static JsonFileConfigurationSource<TConfiguration> FromBaseDirectory<TConfiguration>(
+        string fileName,
+        bool isOptional
+    )
+        where TConfiguration : AllureConfiguration, new()
+    =>
+        new(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, fileName), isOptional);
 }

--- a/src/Allure.Net.Sdk/README.md
+++ b/src/Allure.Net.Sdk/README.md
@@ -111,6 +111,7 @@ select a hook in `allure.config.json`:
 
 ```json
 {
+  "$schema": "https://allure-framework.github.io/allure-csharp/schemas/allure.net.sdk/allure.config.schema.json",
   "runtimeRegistrationHook": "MyTests.ProjectAllureRegistration, MyTests"
 }
 ```

--- a/src/Allure.Net.Sdk/README.md
+++ b/src/Allure.Net.Sdk/README.md
@@ -58,6 +58,21 @@ using var registration = plan.Build();
 IAllureRuntime runtime = registration.Runtime;
 ```
 
+#### Default configuration resolution
+
+Unless an integration selects configuration explicitly, the builder checks
+these sources in order:
+
+1. the file identified by the `ALLURE_CONFIG` environment variable;
+2. `allureConfig.json` in the application base directory;
+3. `allure.config.json` in the application base directory;
+4. default configuration values.
+
+The first available source wins. Sources are not merged, so properties omitted
+by the selected source are not filled from later sources. Selecting a
+configuration or configuration source through the registration context replaces
+this default source list.
+
 The registration action passed to `Prepare` receives an
 `IAllureRuntimeIntegrationContext`. Use that context to:
 
@@ -92,7 +107,7 @@ public sealed class ProjectAllureRegistration :
 By default, the builder looks for hooks in two places: first in the
 `ALLURE_RUNTIME_REGISTRATION_HOOK` environment variable, then in the resolved
 configuration's `runtimeRegistrationHook` property. For example, a user can
-select a hook in `allureConfig.json`:
+select a hook in `allure.config.json`:
 
 ```json
 {

--- a/src/Allure.Net.Sdk/Registration/AllureRegistrationDefaults.cs
+++ b/src/Allure.Net.Sdk/Registration/AllureRegistrationDefaults.cs
@@ -25,6 +25,7 @@ public static class AllureRegistrationDefaults
         static () => [
             JsonFileConfigurationSource.FromPathEnvironmentVariable<TConfiguration>(),
             JsonFileConfigurationSource.FromBaseDirectory<TConfiguration>(true),
+            JsonFileConfigurationSource.FromBaseDirectory<TConfiguration>("allure.config.json", true),
         ];
 
     /// <summary>

--- a/src/Allure.Net.Sdk/schemas/allure.config.schema.json
+++ b/src/Allure.Net.Sdk/schemas/allure.config.schema.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://allure-framework.github.io/allure-csharp/schemas/allure.net.sdk/allure.config.schema.json",
+  "title": "Allure.Net.Sdk configuration",
+  "description": "Common configuration properties supported by Allure.Net.Sdk. Framework integrations may extend this object with additional properties.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "description": "The URL of the JSON Schema used to validate this configuration file.",
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "hostname": {
+      "description": "The host name recorded in generated test results. Defaults to the current machine name.",
+      "type": "string"
+    },
+    "resultsDirectory": {
+      "description": "The absolute or relative path of the directory where Allure result files are written. Relative paths are resolved against the test process working directory.",
+      "type": "string",
+      "minLength": 1
+    },
+    "linkTemplates": {
+      "description": "Link templates indexed by link type. The {0} substitution field represents the original link value.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/linkTemplate"
+      },
+      "default": {}
+    },
+    "failExceptions": {
+      "description": "Exception type names that Allure treats as test failures instead of broken tests.",
+      "type": "array",
+      "items": {
+        "description": "The namespace-qualified or assembly-qualified name of an exception type.",
+        "type": "string",
+        "minLength": 1
+      },
+      "default": []
+    },
+    "indentOutput": {
+      "description": "Whether generated JSON result files are indented.",
+      "type": "boolean",
+      "default": false
+    },
+    "globalLabels": {
+      "description": "Labels applied to every generated test result, indexed by label name.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "runtimeRegistrationHook": {
+      "description": "The assembly-qualified name of the runtime registration hook type.",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "additionalProperties": true,
+  "definitions": {
+    "linkTemplate": {
+      "title": "link template",
+      "description": "Templates used to expand a link URL and, optionally, its display name.",
+      "type": "object",
+      "properties": {
+        "urlTemplate": {
+          "description": "A composite format string for the link URL. The {0} substitution field represents the original link value.",
+          "type": "string",
+          "minLength": 1
+        },
+        "nameTemplate": {
+          "description": "An optional composite format string for the link display name. The {0} substitution field represents the original link value.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "urlTemplate"
+      ],
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/Allure.TestingPlatform/README.md
+++ b/src/Allure.TestingPlatform/README.md
@@ -110,6 +110,7 @@ The canonical JSON format is:
 
 ```json
 {
+  "$schema": "https://allure-framework.github.io/allure-csharp/schemas/allure.testingplatform/allure.config.schema.json",
   "resultsDirectory": "allure-results",
   "hostname": "test-host",
   "linkTemplates": {

--- a/src/Allure.TestingPlatform/README.md
+++ b/src/Allure.TestingPlatform/README.md
@@ -101,7 +101,8 @@ Without explicit registration, configuration is loaded from the first available 
 
 1. the file identified by the `ALLURE_CONFIG` environment variable;
 2. `allureConfig.json` in the application base directory;
-3. default values.
+3. `allure.config.json` in the application base directory;
+4. default values.
 
 An explicit configuration source registered through `AddAllure` replaces that default source list.
 

--- a/src/Allure.TestingPlatform/schemas/allure.config.schema.json
+++ b/src/Allure.TestingPlatform/schemas/allure.config.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://allure-framework.github.io/allure-csharp/schemas/allure.testingplatform/allure.config.schema.json",
+  "title": "Allure.TestingPlatform configuration",
+  "description": "Configuration properties supported by the Allure Microsoft Testing Platform integration. Framework integrations may extend this object with additional properties.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://allure-framework.github.io/allure-csharp/schemas/allure.net.sdk/allure.config.schema.json"
+    }
+  ],
+  "properties": {
+    "isEnabled": {
+      "description": "Whether the Allure integration is enabled.",
+      "type": "boolean",
+      "default": true
+    },
+    "isProcessWatchdogEnabled": {
+      "description": "Whether an Allure global error is written when the test host process exits unexpectedly.",
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/Allure.Xunit.v3/MIGRATION.md
+++ b/src/Allure.Xunit.v3/MIGRATION.md
@@ -112,6 +112,9 @@ The following `Allure.Xunit` properties are not supported: `useLegacyIds`,
 Make sure `allureConfig.json` is copied to the test application's output
 directory, or set `ALLURE_CONFIG` to its path.
 
+You may also rename the file to `allure.config.json`: both names are supported
+with `allureConfig.json` taking precedence.
+
 ## Update namespaces
 
 The current attributes and runtime APIs are in the `Allure` namespace. Model

--- a/src/Allure.Xunit.v3/MIGRATION.md
+++ b/src/Allure.Xunit.v3/MIGRATION.md
@@ -498,17 +498,48 @@ context.ConfigureSerialization(
 );
 ```
 
-Select the hook before Allure registration begins. See
-[Registration hook](README.md#registration-hook) for the available registration
-mechanisms.
+Register the hook from a module initializer by assigning it to
+`AllureXunitRegistrationHook.Current`:
 
-The old type formatter API matched only the exact runtime type. A rule derived
-from `TypedParameterSerializationRule<T>` accepts any value compatible with
-`T`. A rule for a base class therefore also handles its subclasses, and a rule
-for an interface handles implementations of that interface. Delegate rules
-created by `AddDelegateRule<T>` derive from the same typed rule and have the
-same behavior. If multiple rules accept a value, the last added matching rule
-has priority.
+```csharp
+using System.Runtime.CompilerServices;
+using Allure.Xunit.Registration;
+
+internal static class AllureSetup
+{
+    [ModuleInitializer]
+    internal static void Initialize()
+    {
+        AllureXunitRegistrationHook.Current =
+            new ProjectAllureRegistration();
+    }
+}
+```
+
+For details about registration hooks, see
+[Registration hook](https://github.com/allure-framework/allure-csharp/blob/main/src/Allure.Xunit.v3/README.md#registration-hook).
+
+### Type matching and rule priority
+
+The old type formatter API matched only the exact runtime type. In contrast,
+`TypedParameterSerializationRule<T>` and `AddDelegateRule<T>` use normal C#
+type compatibility, including inheritance, interface implementation, and
+generic variance. Because the last matching rule wins, add general rules before
+more specific ones when the specific behavior should take priority:
+
+```csharp
+context.ConfigureSerialization(rules =>
+{
+    rules.AddDelegateRule<Account>(account => account.Id);
+    rules.AddDelegateRule<PremiumAccount>(
+        account => $"premium:{account.Id}"
+    );
+});
+```
+
+Assuming `PremiumAccount` derives from `Account`, both rules match it, so the
+`PremiumAccount` rule must be added last to take priority. The same applies to
+an interface rule and a rule for one of its implementations.
 
 ## Replace ExtendedApi
 

--- a/src/Allure.Xunit.v3/MIGRATION.md
+++ b/src/Allure.Xunit.v3/MIGRATION.md
@@ -74,11 +74,15 @@ configuration just as `Allure.Xunit` does.
 
 ## Update configuration
 
-The old configuration shape is accepted for compatibility, but new projects
-should use the current top-level property names:
+The legacy configuration shape remains supported for compatibility.
+When migrating, move the settings to the current top-level properties.
+Replace an existing $schema value (or add one if it is absent) with the
+`Allure.Xunit.v3` schema URL to enable validation and completion in compatible
+editors:
 
 ```diff
 -{
+-  "$schema": "https://raw.githubusercontent.com/allure-framework/allure-csharp/refs/heads/main/src/Allure.Xunit/Schemas/allureConfig.schema.json",
 -  "allure": {
 -    "title": "build-agent",
 -    "directory": "allure-results",
@@ -88,6 +92,7 @@ should use the current top-level property names:
 -  }
 -}
 +{
++  "$schema": "https://allure-framework.github.io/allure-csharp/schemas/allure.xunit.v3/allure.config.schema.json",
 +  "hostname": "build-agent",
 +  "resultsDirectory": "allure-results",
 +  "linkTemplates": {

--- a/src/Allure.Xunit.v3/README.md
+++ b/src/Allure.Xunit.v3/README.md
@@ -151,9 +151,10 @@ Example configuration:
 
 ```json
 {
+  "$schema": "https://allure-framework.github.io/allure-csharp/schemas/allure.xunit.v3/allure.config.schema.json",
   "resultsDirectory": "allure-results",
   "hostname": "build-agent",
-  "linkTemplate": {
+  "linkTemplates": {
     "issue": {
       "urlTemplate": "https://github.com/allure-framework/allure-csharp/issues/{0}",
       "nameTemplate": "Issue {0}"
@@ -306,6 +307,7 @@ Alternatively, select the hook through the `runtimeRegistrationHook` property in
 
 ```json
 {
+  "$schema": "https://allure-framework.github.io/allure-csharp/schemas/allure.xunit.v3/allure.config.schema.json",
   "runtimeRegistrationHook":
     "MyTests.ProjectAllureRegistration, MyTests"
 }

--- a/src/Allure.Xunit.v3/README.md
+++ b/src/Allure.Xunit.v3/README.md
@@ -67,6 +67,8 @@ registered and the project will not produce Allure results through this package.
 
 `Allure.Xunit.v3` currently has the following limitations:
 
+- It does not support the native xUnit.net runner. The project must enable
+  the MTP runner.
 - Unlike `Allure.Xunit`, it cannot delegate to or run alongside a second xUnit
   runner reporter.
 - It cannot be used in the same test process with another integration based on
@@ -76,6 +78,10 @@ registered and the project will not produce Allure results through this package.
 - Instrumentation attributes such as `AllureStep`, `AllureSetUp`,
   `AllureTearDown`, and attachment attributes use AspectInjector. On Apple
   silicon Macs, using these attributes may require Rosetta 2.
+- In server mode, the configuration is not re-read until the process is
+  restarted.
+- Only one MTP request can be active at a time; parallel requests are not
+  supported.
 
 ## Quick Start
 
@@ -128,34 +134,35 @@ are not supported yet.
 
 ## Configuration
 
-The default registration checks the same configuration sources as
-`Allure.TestingPlatform`, in order from highest to lowest precedence:
-
-1. explicit configuration passed during custom registration;
-2. the file path from the `ALLURE_CONFIG` environment variable;
-3. `allureConfig.json` from the application base directory;
-4. default configuration values.
-
-The first source that provides a configuration wins, and resolution stops.
-Configuration sources are not merged: values omitted by the selected source
-are not filled from sources later in the list.
-
-An `allureConfig.json` file can be copied to the output directory:
+Create `allure.config.json` with the required configuration and make sure the
+file is copied to the output directory:
 
 ```xml
 <ItemGroup>
-  <None Update="allureConfig.json">
+  <None Update="allure.config.json">
     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
   </None>
 </ItemGroup>
 ```
+
+The old `allureConfig.json` name is also supported.
 
 Example configuration:
 
 ```json
 {
   "resultsDirectory": "allure-results",
-  "hostname": "build-agent"
+  "hostname": "build-agent",
+  "linkTemplate": {
+    "issue": {
+      "urlTemplate": "https://github.com/allure-framework/allure-csharp/issues/{0}",
+      "nameTemplate": "Issue {0}"
+    }
+  },
+  "globalLabels": {
+    "layer": "unit",
+    "project": "Allure.Xunit.v3"
+  }
 }
 ```
 
@@ -173,6 +180,8 @@ All properties are optional. JSON property names are case-sensitive.
 | `isEnabled` | `true` | Whether the Allure integration is enabled. |
 | `isProcessWatchdogEnabled` | `true` | Whether an Allure global error is written when the test host process exits unexpectedly. |
 
+### CLI arguments
+
 The `--allure`, `--allure-watchdog`, and `--allure-results-directory`
 command-line options override their corresponding configuration properties for
 the current run:
@@ -182,6 +191,21 @@ dotnet test -- --allure off
 dotnet test -- --allure-watchdog off
 dotnet test -- --allure-results-directory ./artifacts/allure-results
 ```
+
+### Configuration resolution
+
+The default registration checks the following configuration sources
+in order from highest to lowest precedence:
+
+1. explicit configuration passed during custom registration;
+2. the file path from the `ALLURE_CONFIG` environment variable;
+3. `allureConfig.json` from the application base directory;
+4. `allure.config.json` from the application base directory;
+5. default configuration values.
+
+The first source that provides a configuration wins, and resolution stops.
+Configuration sources are not merged: values omitted by the selected source
+are not filled from sources later in the list.
 
 ## Selective run
 
@@ -278,7 +302,7 @@ internal static class AllureSetup
 ```
 
 Alternatively, select the hook through the `runtimeRegistrationHook` property in
-`allureConfig.json`. Specify the hook type followed by the name of its assembly:
+`allure.config.json`. Specify the hook type followed by the name of its assembly:
 
 ```json
 {

--- a/src/Allure.Xunit.v3/schemas/allure.config.schema.json
+++ b/src/Allure.Xunit.v3/schemas/allure.config.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://allure-framework.github.io/allure-csharp/schemas/allure.xunit.v3/allure.config.schema.json",
+  "title": "Allure.Xunit.v3 configuration",
+  "description": "Configuration properties supported by the Allure xUnit.net v3 integration.",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://allure-framework.github.io/allure-csharp/schemas/allure.testingplatform/allure.config.schema.json"
+    }
+  ],
+  "additionalProperties": true
+}

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -15,6 +15,10 @@
         <NuGetPackInput Include="$(Allure_TransformReadmeSource)" />
     </ItemGroup>
 
+    <UsingTask
+        TaskName="Allure.Build.Tasks.PrepareConfigSchema"
+        AssemblyFile="$(_Allure_BuildTaskAssemblyPath)"/>
+
     <UsingTask TaskName="Allure_TransformReadmeForNuget"
             TaskFactory="RoslynCodeTaskFactory"
             AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
@@ -58,4 +62,31 @@
             </_PackageFiles>
         </ItemGroup>
     </Target>
+
+    <PropertyGroup>
+        <_Allure_ConfigurationSchema>$(
+            [MSBuild]::NormalizePath(
+                '$(MSBuildProjectDirectory)',
+                './schemas/allure.config.schema.json'
+            )
+        )</_Allure_ConfigurationSchema>
+
+        <_Allure_SchemaSitePath>$(
+            [MSBuild]::NormalizeDirectory(
+                '$(ArtifactsPath)',
+                'schema-site'
+            )
+        )</_Allure_SchemaSitePath>
+    </PropertyGroup>
+
+    <Target Name="Allure_PrepareSchemas"
+            Condition=" Exists('$(_Allure_ConfigurationSchema)') And '$(IsPackable)' == 'true' "
+            DependsOnTargets="_Allure_CompileBuildTasks">
+        <Allure.Build.Tasks.PrepareConfigSchema
+            InputPath="$(_Allure_ConfigurationSchema)"
+            OutputDirectory="$(_Allure_SchemaSitePath)"
+            Version="$(Version)"
+            PackageName="$(PackageId)"/>
+    </Target>
+
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -11,6 +11,22 @@
         <Allure_TransformReadmeSource>$([MSBuild]::NormalizePath('$(MSBuildThisFileDirectory)', '..', 'build', 'TransformReadmeForNuget.cs'))</Allure_TransformReadmeSource>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <_Allure_ConfigurationSchema>$(
+            [MSBuild]::NormalizePath(
+                '$(MSBuildProjectDirectory)',
+                './schemas/allure.config.schema.json'
+            )
+        )</_Allure_ConfigurationSchema>
+
+        <_Allure_SchemaSitePath>$(
+            [MSBuild]::NormalizeDirectory(
+                '$(ArtifactsPath)',
+                'schema-site'
+            )
+        )</_Allure_SchemaSitePath>
+    </PropertyGroup>
+
     <ItemGroup>
         <NuGetPackInput Include="$(Allure_TransformReadmeSource)" />
     </ItemGroup>
@@ -43,17 +59,20 @@
     NuGet doesn't support <img> tags well (in particular, the align, width and height properties).
     This task generates a new README file with those unsupported constructs removed.
     -->
-    <Target Name="Allure_GenerateNugetReadmeFiles"
-            BeforeTargets="GenerateNuspec"
-            Condition="'$(IsPackable)' == 'true'"
+    <Target Name="_Allure_GenerateNugetReadmeFile"
             Inputs="@(NuGetPackInput)" Outputs="@(NuGetPackOutput)">
+
         <Allure_TransformReadmeForNuget
             InputReadmePath="README.md"
             OutputDirPath="$(BaseIntermediateOutputPath)">
+
             <Output TaskParameter="GeneratedReadmePath"
                 PropertyName="Allure_NugetTransformedReadmePath" />
+
         </Allure_TransformReadmeForNuget>
+
         <Message Text="A new README was generated for $(MSBuildProjectName) at $(Allure_NugetTransformedReadmePath)" Importance="high" />
+
         <ItemGroup>
             <_PackageFiles Remove="README.md" />
             <_PackageFiles Include="$(Allure_NugetTransformedReadmePath)">
@@ -63,21 +82,32 @@
         </ItemGroup>
     </Target>
 
-    <PropertyGroup>
-        <_Allure_ConfigurationSchema>$(
-            [MSBuild]::NormalizePath(
-                '$(MSBuildProjectDirectory)',
-                './schemas/allure.config.schema.json'
-            )
-        )</_Allure_ConfigurationSchema>
+    <Target Name="_Allure_AddConfigurationSchema"
+        Condition="Exists('$(_Allure_ConfigurationSchema)')"
+        DependsOnTargets="_Allure_CompileBuildTasks">
 
-        <_Allure_SchemaSitePath>$(
-            [MSBuild]::NormalizeDirectory(
-                '$(ArtifactsPath)',
-                'schema-site'
-            )
-        )</_Allure_SchemaSitePath>
-    </PropertyGroup>
+        <Allure.Build.Tasks.PrepareConfigSchema
+            InputPath="$(_Allure_ConfigurationSchema)"
+            OutputDirectory="$(BaseIntermediateOutputPath)"
+            Version="$(Version)"
+            PackageName="$(PackageId)">
+
+            <Output TaskParameter="VersionedSchemaPath" PropertyName="_Allure_VersionedSchemaPath" />
+
+        </Allure.Build.Tasks.PrepareConfigSchema>
+
+        <ItemGroup>
+            <_PackageFiles Condition="Exists('$(_Allure_VersionedSchemaPath)')" Include="$(_Allure_VersionedSchemaPath)">
+                <BuildAction>None</BuildAction>
+                <PackagePath>/schemas/allure.config.schema.json</PackagePath>
+            </_PackageFiles>
+        </ItemGroup>
+    </Target>
+
+    <Target Name="_Allure_IncludeDynamicPackageContent"
+        BeforeTargets="GenerateNuspec"
+        Condition="'$(IsPackable)' == 'true'"
+        DependsOnTargets="_Allure_GenerateNugetReadmeFile;_Allure_AddConfigurationSchema"/>
 
     <Target Name="Allure_PrepareSchemas"
             Condition=" Exists('$(_Allure_ConfigurationSchema)') And '$(IsPackable)' == 'true' "

--- a/tests/Allure.ConfigSchema.Tests/Allure.ConfigSchema.Tests.csproj
+++ b/tests/Allure.ConfigSchema.Tests/Allure.ConfigSchema.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JsonSchema.Net" Version="9.4.0" />
+    <PackageReference Include="TUnit" Version="1.61.29" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="../../src/Allure.Net.Sdk/schemas/allure.config.schema.json"
+             Link="schemas/allure.net.sdk/allure.config.schema.json"
+             CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../src/Allure.TestingPlatform/schemas/allure.config.schema.json"
+             Link="schemas/allure.testingplatform/allure.config.schema.json"
+             CopyToOutputDirectory="PreserveNewest" />
+    <None Include="../../src/Allure.Xunit.v3/schemas/allure.config.schema.json"
+             Link="schemas/allure.xunit.v3/allure.config.schema.json"
+             CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Allure.ConfigSchema.Tests/ConfigSchemaTests.cs
+++ b/tests/Allure.ConfigSchema.Tests/ConfigSchemaTests.cs
@@ -1,0 +1,145 @@
+using System.Text.Json;
+using Json.Schema;
+
+namespace Allure.ConfigSchema.Tests;
+
+public class ConfigSchemaTests
+{
+    const string Sdk = "allure.net.sdk";
+    const string TestingPlatform = "allure.testingplatform";
+    const string XunitV3 = "allure.xunit.v3";
+
+    static readonly string[] Packages = [Sdk, TestingPlatform, XunitV3];
+
+    static readonly Lazy<Dictionary<string, JsonSchema>> Schemas = new(
+        LoadSchemas
+    );
+
+    [Test]
+    [Arguments(Sdk)]
+    [Arguments(TestingPlatform)]
+    [Arguments(XunitV3)]
+    public async Task ShouldConformToDraft7MetaSchema(string packageName)
+    {
+        using var schema = JsonDocument.Parse(
+            await File.ReadAllTextAsync(GetSchemaPath(packageName))
+        );
+        var result = MetaSchemas.Draft7.Evaluate(schema.RootElement);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    [Test]
+    [Arguments(Sdk, "{}")]
+    [Arguments(Sdk, """
+        {
+          "$schema": "https://example.test/allure.config.schema.json",
+          "hostname": "test-host",
+          "resultsDirectory": "allure-results",
+          "linkTemplates": {
+            "issue": {
+              "urlTemplate": "https://issues.example.test/{0}",
+              "nameTemplate": "Issue {0}"
+            }
+          },
+          "failExceptions": ["Example.AssertionException"],
+          "indentOutput": true,
+          "globalLabels": {
+            "owner": "allure"
+          },
+          "runtimeRegistrationHook": null
+        }
+        """)]
+    [Arguments(TestingPlatform, """
+        {
+          "resultsDirectory": "allure-results",
+          "isEnabled": true,
+          "isProcessWatchdogEnabled": false
+        }
+        """)]
+    [Arguments(XunitV3, """
+        {
+          "hostname": "test-host",
+          "indentOutput": true,
+          "isEnabled": true,
+          "isProcessWatchdogEnabled": false
+        }
+        """)]
+    [Arguments(XunitV3, """
+        {
+          "customFrameworkOption": "allowed"
+        }
+        """)]
+    public async Task ShouldAcceptValidConfiguration(string packageName, string configuration)
+    {
+        var result = Evaluate(packageName, configuration);
+
+        await Assert.That(result.IsValid).IsTrue();
+    }
+
+    [Test]
+    [Arguments(Sdk, """
+        {
+          "indentOutput": "true"
+        }
+        """)]
+    [Arguments(Sdk, """
+        {
+          "linkTemplates": {
+            "issue": {}
+          }
+        }
+        """)]
+    [Arguments(Sdk, """
+        {
+          "linkTemplates": {
+            "issue": {
+              "urlTemplate": "https://issues.example.test/{0}",
+              "unknown": true
+            }
+          }
+        }
+        """)]
+    [Arguments(TestingPlatform, """
+        {
+          "isEnabled": "true"
+        }
+        """)]
+    [Arguments(XunitV3, """
+        {
+          "resultsDirectory": ""
+        }
+        """)]
+    [Arguments(XunitV3, """
+        {
+          "isProcessWatchdogEnabled": 1
+        }
+        """)]
+    public async Task ShouldRejectInvalidConfiguration(string packageName, string configuration)
+    {
+        var result = Evaluate(packageName, configuration);
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+
+    static EvaluationResults Evaluate(string packageName, string configuration)
+    {
+        using var instance = JsonDocument.Parse(configuration);
+
+        return Schemas.Value[packageName].Evaluate(instance.RootElement);
+    }
+
+    static Dictionary<string, JsonSchema> LoadSchemas() => Packages.ToDictionary(
+        packageName => packageName,
+        packageName => JsonSchema.FromFile(
+            GetSchemaPath(packageName)
+        )
+    );
+
+    static string GetSchemaPath(string packageName) => Path.Combine(
+        AppContext.BaseDirectory,
+        "schemas",
+        packageName,
+        "allure.config.schema.json"
+    );
+}

--- a/tests/Allure.Net.Sdk.Tests/Registration/ConfigurationResolutionTests.cs
+++ b/tests/Allure.Net.Sdk.Tests/Registration/ConfigurationResolutionTests.cs
@@ -1,6 +1,6 @@
 using Allure.Sdk.Configuration;
 using Allure.Sdk.Registration;
-using Allure.Net.Sdk.Tests.Infrastructure;
+using Allure.Sdk.Results;
 
 namespace Allure.Net.Sdk.Tests.Registration;
 
@@ -162,12 +162,157 @@ public class ConfigurationResolutionTests
         }
     }
 
+    [Test]
+    [NotInParallel]
+    public async Task ShouldLoadLegacyDefaultConfigurationFile()
+    {
+        using var state = new DefaultConfigurationState();
+        await state.WriteLegacyConfiguration("legacy");
+
+        var configuration = ResolveDefaultConfiguration();
+
+        await Assert.That(configuration.Value).IsEqualTo("legacy");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ShouldLoadDottedDefaultConfigurationFile()
+    {
+        using var state = new DefaultConfigurationState();
+        await state.WriteDottedConfiguration("dotted");
+
+        var configuration = ResolveDefaultConfiguration();
+
+        await Assert.That(configuration.Value).IsEqualTo("dotted");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ShouldPreferLegacyDefaultConfigurationFile()
+    {
+        using var state = new DefaultConfigurationState();
+        await state.WriteLegacyConfiguration("legacy");
+        await state.WriteDottedConfiguration("dotted");
+
+        var configuration = ResolveDefaultConfiguration();
+
+        await Assert.That(configuration.Value).IsEqualTo("legacy");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task ShouldPreferEnvironmentConfigurationFile()
+    {
+        using var state = new DefaultConfigurationState();
+        await state.WriteLegacyConfiguration("legacy");
+        await state.WriteDottedConfiguration("dotted");
+        await state.WriteEnvironmentConfiguration("environment");
+
+        var configuration = ResolveDefaultConfiguration();
+
+        await Assert.That(configuration.Value).IsEqualTo("environment");
+    }
+
+    static TestConfiguration ResolveDefaultConfiguration()
+    {
+        var builder = CreateBuilder();
+        var plan = builder.Prepare((ctx) =>
+        {
+            ctx.UseDestination(_ => new InMemoryResultsDestination());
+        });
+
+        using var runtime = plan.Build();
+        return runtime.Runtime.Configuration;
+    }
+
     static AllureRuntimeBuilder<TestConfiguration> CreateBuilder() =>
         new("configuration-tests");
 
     sealed record class TestConfiguration : AllureConfiguration
     {
         public string? Value { get; init; }
+    }
+
+    sealed class DefaultConfigurationState : IDisposable
+    {
+        const string EnvironmentVariableName = "ALLURE_CONFIG";
+
+        static readonly string LegacyConfigurationPath = Path.Combine(
+            AppDomain.CurrentDomain.BaseDirectory,
+            "allureConfig.json"
+        );
+
+        static readonly string DottedConfigurationPath = Path.Combine(
+            AppDomain.CurrentDomain.BaseDirectory,
+            "allure.config.json"
+        );
+
+        readonly string? previousEnvironmentConfigurationPath =
+            Environment.GetEnvironmentVariable(EnvironmentVariableName);
+        readonly byte[]? previousLegacyConfiguration = ReadIfExists(
+            LegacyConfigurationPath
+        );
+        readonly byte[]? previousDottedConfiguration = ReadIfExists(
+            DottedConfigurationPath
+        );
+        string? environmentConfigurationPath;
+
+        public DefaultConfigurationState()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariableName, null);
+            File.Delete(LegacyConfigurationPath);
+            File.Delete(DottedConfigurationPath);
+        }
+
+        public Task WriteLegacyConfiguration(string value) =>
+            WriteConfiguration(LegacyConfigurationPath, value);
+
+        public Task WriteDottedConfiguration(string value) =>
+            WriteConfiguration(DottedConfigurationPath, value);
+
+        public async Task WriteEnvironmentConfiguration(string value)
+        {
+            this.environmentConfigurationPath = Path.Combine(
+                Path.GetTempPath(),
+                $"allure-sdk-config-{Guid.NewGuid():N}.json"
+            );
+            await WriteConfiguration(this.environmentConfigurationPath, value);
+            Environment.SetEnvironmentVariable(
+                EnvironmentVariableName,
+                this.environmentConfigurationPath
+            );
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(
+                EnvironmentVariableName,
+                this.previousEnvironmentConfigurationPath
+            );
+            File.Delete(LegacyConfigurationPath);
+            File.Delete(DottedConfigurationPath);
+            Restore(LegacyConfigurationPath, this.previousLegacyConfiguration);
+            Restore(DottedConfigurationPath, this.previousDottedConfiguration);
+
+            if (this.environmentConfigurationPath is not null)
+            {
+                File.Delete(this.environmentConfigurationPath);
+            }
+        }
+
+        static byte[]? ReadIfExists(string path) =>
+            File.Exists(path) ? File.ReadAllBytes(path) : null;
+
+        static Task WriteConfiguration(string path, string value) =>
+            File.WriteAllTextAsync(path, $$"""{"value":"{{value}}"}""");
+
+        static void Restore(string path, byte[]? contents)
+        {
+            if (contents is not null)
+            {
+                File.WriteAllBytes(path, contents);
+            }
+        }
     }
 
     sealed class RecordingConfigurationSource : IAllureConfigurationSource<TestConfiguration>

--- a/tests/Allure.Net.Sdk.Tests/Serialization/SerializationConfigurationTests.cs
+++ b/tests/Allure.Net.Sdk.Tests/Serialization/SerializationConfigurationTests.cs
@@ -60,6 +60,19 @@ public class SerializationConfigurationTests
     }
 
     [Test]
+    public async Task ShouldApplyDelegateRuleThroughGenericVariance()
+    {
+        var serializer = CreateSerializer(
+            context => context.AddDelegateRule<IConverter<string, object>>(
+                value => $"variant:{value.Convert("value")}"
+            )
+        );
+
+        await Assert.That(serializer.Serialize(new ObjectToStringConverter()))
+            .IsEqualTo("variant:value");
+    }
+
+    [Test]
     public async Task ShouldReplaceDefaultJsonOptions()
     {
         var serializer = CreateSerializer(
@@ -207,6 +220,16 @@ public class SerializationConfigurationTests
     }
 
     sealed record class NamedValue(string Name) : INamedValue;
+
+    interface IConverter<in TInput, out TOutput>
+    {
+        TOutput Convert(TInput input);
+    }
+
+    sealed class ObjectToStringConverter : IConverter<object, string>
+    {
+        public string Convert(object input) => input.ToString()!;
+    }
 
     sealed class JsonObject
     {

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -2,44 +2,6 @@
     <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))"
             Condition="'' != $([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
 
-    <PropertyGroup>
-        <_Allure_RepoRoot>$(
-            [MSBuild]::NormalizePath(
-                '$(MSBuildThisFileDirectory)',
-                '..',
-            )
-        )</_Allure_RepoRoot>
-        <_Allure_BuildTaskProjectName>Allure.Build.Tasks</_Allure_BuildTaskProjectName>
-        <_Allure_BuildTaskProjectDir>$(
-            [MSBuild]::NormalizeDirectory(
-                '$(_Allure_RepoRoot)',
-                'build',
-                '$(_Allure_BuildTaskProjectName)'
-            )
-        )</_Allure_BuildTaskProjectDir>
-        <_Allure_BuildTaskAssemblyPath>$(
-            [MSBuild]::NormalizePath(
-                '$(ArtifactsPath)',
-                'bin',
-                '$(_Allure_BuildTaskProjectName)',
-                'release',
-                '$(_Allure_BuildTaskProjectName).dll'
-            )
-        )</_Allure_BuildTaskAssemblyPath>
-        <_Allure_BinDirectory>$(
-            [MSBuild]::NormalizePath(
-                '$(ArtifactsPath)',
-                'bin'
-            )
-        )</_Allure_BinDirectory>
-        <_Allure_ObjDirectory>$(
-            [MSBuild]::NormalizePath(
-                '$(ArtifactsPath)',
-                'obj'
-            )
-        )</_Allure_ObjDirectory>
-    </PropertyGroup>
-
     <!-- Normalize casing, set the test MSBuild target -->
     <Choose>
         <When Condition=" '$(Allure_TestingPlatform)' == 'VsTest' ">
@@ -93,42 +55,8 @@
         <DefineConstants>$(DefineConstants);ALLURE_TEST_PRERUN_FLOW</DefineConstants>
     </PropertyGroup>
 
-    <ItemGroup>
-        <_Allure_CompileBuildTasksInput Include="$(_Allure_BuildTaskProjectDir)**/*" />
-        <_Allure_CompileBuildTasksInput Include="$([MSBuild]::NormalizePath(
-            '$(_Allure_RepoRoot)',
-            'Directory.Build.props'
-        ))" />
-        <_Allure_CompileBuildTasksInput Include="$([MSBuild]::NormalizePath(
-            '$(_Allure_RepoRoot)',
-            'Directory.Build.targets'
-        ))" />
-    </ItemGroup>
-
     <Target Name="Allure_FailIfError" Condition=" '$(_Allure_Error)' != '' ">
         <Error Text="$(_Allure_Error)" />
-    </Target>
-
-    <Target
-        Name="_Allure_CompileBuildTasks"
-        Inputs="@(_Allure_CompileBuildTasksInput)"
-        Outputs="$(_Allure_BuildTaskAssemblyPath)">
-
-        <PropertyGroup>
-            <_Allure_BuildTasksProject>$(
-                [MSBuild]::NormalizePath(
-                    '$(_Allure_BuildTaskProjectDir)',
-                    '$(_Allure_BuildTaskProjectName).csproj'
-                )
-            )</_Allure_BuildTasksProject>
-        </PropertyGroup>
-
-        <MSBuild
-            Projects="$(_Allure_BuildTasksProject)"
-            Targets="Restore;Build"
-            BuildInParallel="$(BuildInParallel)"
-            Properties="Configuration=Release" />
-
     </Target>
 
     <Target


### PR DESCRIPTION
### Context

The PR adds configuration schemas to `Allure.Net.Sdk`, `Allure.TestingPlatform`, and `Allure.Xunit.v3` and a schema publishing workflow that uploads the schemas to GitHub Pages. The workflow is run automatically after the NuGet publishing succeeds. It can also be run manually.

The PR also adds relevant schema links to provided configuration snippets.

Other changes:

  - Bump `actions/checkout` to `v7` and `actions/setup-dotnet` to `v6` in `publish.yml`.
  - Support `allure.config.json` as the configuration file name in `Allure.Net.Sdk` and updated READMEs to promote this name instead of `allureConfig.json`.
  - Add a new overload of `JsonFileConfigurationSource<TConfiguration>.FromBaseDirectory` that accepts an arbitrary file name.
  - Describe the default configuration resolution in `Allure.Net.Sdk` README.
  - Better document the transition from the old type formatters API to the new serialization rules API. Explain how to register the hook.
  - Add missing `Allure.Xunit.v3` limitations to README.
  - Add a test for generic variance support of serialization rules.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-csharp
